### PR TITLE
Fix link to @nuxtjs/tailwindcss repo

### DIFF
--- a/content/en/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/en/docs/5.configuration-glossary/2.configuration-build.md
@@ -540,7 +540,7 @@ export default {
 
 ### postcss plugins & @nuxtjs/tailwindcss
 
-If you want to apply a postcss plugin (e.g. postcss-pxtorem) on the @nuxtjs/tailwindcss configuration, you have to change order and load tailwindcss first.
+If you want to apply a postcss plugin (e.g. postcss-pxtorem) on the [@nuxtjs/tailwindcss](https://github.com/nuxt-community/tailwindcss-module) configuration, you have to change order and load tailwindcss first.
 
 **This setup has no impact on nuxt-purgecss.**
 


### PR DESCRIPTION
From https://github.com/nuxtjs/tailwindcss (404)
to https://github.com/nuxt-community/tailwindcss-module