### PR TITLE
feat: update v3 page

### DIFF
--- a/components/organisms/heroes/Nuxt3Hero.vue
+++ b/components/organisms/heroes/Nuxt3Hero.vue
@@ -97,7 +97,7 @@ export default defineComponent({
   setup() {
     const { email, error, subscribe, pending, subscribed } = useNewsletter()
 
-    const date = ref(parseISO('2021-10-12T14:00:00+02:00'))
+    const date = ref(parseISO('2021-10-12T16:00:00+02:00'))
     const now = new Date()
 
     const isDatePassed = date.value.getTime() - now.getTime() < 0


### PR DESCRIPTION
Update v3 page to handle passed countdown, even if `/v3` will redirect to `v3.nuxtjs.org`.