### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ yarn dev
 
 The pages are generated from [docs/content/](./docs/content), you can start editing them to start helping us on documenting Nuxt 💚
 
-## Lisense
+## License
 
 <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nd/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">Design materials for website</span> by <span xmlns:cc="http://creativecommons.org/ns#" property="cc:attributionName">Nuxt project</span> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nd/4.0/">Creative Commons Attribution-NoDerivatives 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://github.com/nuxt/nuxtjs.org" rel="dct:source">nuxt/nuxtjs.org</a>.
 


### PR DESCRIPTION
The `Lisense` seems to be misspelled. 

Thanks for this exciting framework! I'd been looking forward to nuxt 3.
(I'm sorry if my English is wrong)