### PR TITLE
Clarify Nuxt 3 beta announcement

### DIFF
--- a/content/en/announcements/5.nuxt3-beta.md
+++ b/content/en/announcements/5.nuxt3-beta.md
@@ -1,7 +1,7 @@
 ---
 template: post
 title: Introducing Nuxt 3 Beta
-description: "468 days after the first commit, Nuxt 3 is finally out of beta. Discover what's inside and what to expect from it. Yes, it includes Vue 3 and Vite ⚡️"
+description: "468 days after the first commit, the Nuxt 3 beta has finally arrived. Discover what's inside and what to expect from it. Yes, it includes Vue 3 and Vite ⚡️"
 imgUrl: blog/nuxt3-beta/main.jpg
 date: 2021-10-12
 authors:


### PR DESCRIPTION
The beta announcement says that Nuxt 3 is "finally out of beta." This contradicts the rest of the post, which says that Nuxt 3 has just *reached* its beta stage of release. "Out of beta" means that the beta test is complete and Nuxt has reached a production release.

This change adjusts the wording to clarify that this is the start of the beta, not the end of the beta.