### PR TITLE
WIP: Remove 0 Bind Address

### DIFF
--- a/content/en/docs/3.features/6.configuration.md
+++ b/content/en/docs/3.features/6.configuration.md
@@ -387,12 +387,12 @@ export default {
 
 By default, the Nuxt development server host is `localhost`  which is only accessible from within the host machine. In order to view your app on another device you need to modify the host. You can modify the host in your nuxt.config.js file.
 
-Host `'0.0.0.0'`  is designated to tell Nuxt to resolve a host address, which is accessible to connections *outside* of the host machine (e.g. LAN). If the host is assigned the string value of `'0'` (not 0, which is falsy), or `'0.0.0.0'` your local IP address will be assigned to your Nuxt application.
+Host `'0.0.0.0'`  is designated to tell Nuxt to resolve a host address, which is accessible to connections *outside* of the host machine (e.g. LAN). If the host is assigned the string value of `'0.0.0.0'` your local IP address will be assigned to your Nuxt application.
 
 ```js [nuxt.config.js]
 export default {
   server: {
-    host: '0' // default: localhost
+    host: '0.0.0.0' // default: localhost
   }
 }
 ```


### PR DESCRIPTION
Hey, 

I'm quite new here, since i didn't find a contributing file, i seek for assistance if anything is wrong in this PR.

I edited the documentation and changed the "recommended" way to set the host address to `0.0.0.0`. Since `0.0.0.0` is the standard way to assign all IPv4 addresses on the local machine. In networking `0` is a uncommon way to bind all IP Adresses.

This fiexes also the Issue that Nuxt.js projects on Windows cannot assign any IP address, since Windows did not know `0`.

Thanks!