### PR TITLE
chore(Algolia): fix Docus DocSearch config

### DIFF
--- a/docus.config.ts
+++ b/docus.config.ts
@@ -8,9 +8,7 @@ export default {
   algolia: {
     apiKey: 'ff80fbf046ce827f64f06e16f82f1401',
     indexName: 'nuxtjs',
-    searchParameters: {
-      facetFilters: ['tags:main']
-    }
+    facetFilters: ['tags:main']
   },
   layout: {
     aside: false,


### PR DESCRIPTION
`facetFilters` should be at root of `docus.config` `algolia` config