### PR TITLE
docs: update old ssr/css link

### DIFF
--- a/content/en/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/en/docs/5.configuration-glossary/2.configuration-build.md
@@ -193,7 +193,7 @@ export default {
 
 ## extractCSS
 
-> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
+> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://v2.ssr.vuejs.org/guide/css.html).
 
 - Type: `Boolean` or `Object`
 - Default: `false`

--- a/content/es/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/es/docs/5.configuration-glossary/2.configuration-build.md
@@ -193,7 +193,7 @@ export default {
 
 ## extractCSS
 
-> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
+> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://v2.ssr.vuejs.org/guide/css.html).
 
 - Type: `Boolean` or `Object`
 - Default: `false`

--- a/content/fr/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/fr/docs/5.configuration-glossary/2.configuration-build.md
@@ -194,7 +194,7 @@ export default {
 
 ## extractCSS
 
-> Permet le `Common CSS Extraction` en utilisant les [directives](https://ssr.vuejs.org/en/css.html) du package `Vue Server Renderer`.
+> Permet le `Common CSS Extraction` en utilisant les [directives](https://v2.ssr.vuejs.org/guide/css.html) du package `Vue Server Renderer`.
 
 - Type: `Boolean` ou `Object`
 - Par défaut: `false`

--- a/content/ja/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/ja/docs/5.configuration-glossary/2.configuration-build.md
@@ -193,7 +193,7 @@ export default {
 
 ## extractCSS
 
-> Vue サーバーサイドレンダリング[ガイドライン](https://ssr.vuejs.org/en/css.html)を使って共通の CSS を抽出できるようにします。
+> Vue サーバーサイドレンダリング[ガイドライン](https://v2.ssr.vuejs.org/guide/css.html)を使って共通の CSS を抽出できるようにします。
 
 - 型: `Boolean` または `Object`
 - デフォルト: `false`

--- a/content/pt-br/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/pt-br/docs/5.configuration-glossary/2.configuration-build.md
@@ -193,7 +193,7 @@ export default {
 
 ## extractCSS
 
-> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://ssr.vuejs.org/en/css.html).
+> Enables Common CSS Extraction using Vue Server Renderer [guidelines](https://v2.ssr.vuejs.org/guide/css.html).
 
 - Type: `Boolean` or `Object`
 - Default: `false`

--- a/content/pt/docs/5.configuration-glossary/2.configuration-build.md
+++ b/content/pt/docs/5.configuration-glossary/2.configuration-build.md
@@ -193,7 +193,7 @@ export default {
 
 ## A propriedade extractCSS
 
-> Ativa a Common CSS Extraction (Extração Comum do CSS) usando as [orientações](https://ssr.vuejs.org/en/css.html) do Vue Server Renderer (Servidor Renderizador do Vue).
+> Ativa a Common CSS Extraction (Extração Comum do CSS) usando as [orientações](https://v2.ssr.vuejs.org/guide/css.html) do Vue Server Renderer (Servidor Renderizador do Vue).
 
 - Tipo: `Boolean` ou `Object`
 - Padrão: `false`


### PR DESCRIPTION
Now https://ssr.vuejs.org/en/css.html will redirect to https://vuejs.org/guide/scaling-up/ssr.html, this PR updates the link to https://v2.ssr.vuejs.org/en/css.html.