### PR TITLE
Update fr link 2.active-link-classes.md

### DIFF
--- a/content/fr/examples/1.routing/2.active-link-classes.md
+++ b/content/fr/examples/1.routing/2.active-link-classes.md
@@ -14,7 +14,7 @@ Dans cet exemple :
 `layouts/default.vue` montre les styles de `nuxt-link-active` et `nuxt-link-exact-active`.
 
 ::alert{type="next"}
-En savoir plus sur les classes `active` et `exact-active` de [vue-router](https://v3.router.vuejs.org/ja/api/#exact-active-class).
+En savoir plus sur les classes `active` et `exact-active` de [vue-router](https://v3.router.vuejs.org/fr/api/#exact-active-class).
 ::
 
 ::alert{type="next"}


### PR DESCRIPTION
The link currently points to ja locale.
This PR intends to points to the fr version of the documentation instead