### PR TITLE
docs(pt): update `get-started` folder and `concepts/index.md` file

### DIFF
--- a/content/pt/docs/1.get-started/1.installation.md
+++ b/content/pt/docs/1.get-started/1.installation.md
@@ -1,102 +1,103 @@
 ---
 title: Instalação
-description: Aqui, você vai encontrar informações sobre como configurar e iniciar um projeto Nuxt em 4 passos.
+description: Neste artigo, encontraremos informação sobre como configurar e executar um projeto de Nuxt dentro de 4 passos.
 category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/01_installation?fontsize=14&hidenavigation=1&theme=dark
 CreateNuxtAppVideo: wHkPjOmJTt0
-CreateNuxtAppVideoTitle: Usando create-nuxt-app
+CreateNuxtAppVideoTitle: Usar a create-nuxt-app
 ManualInstallVideo: mKV_9AIG70E
-ManualInstallVideoTitle: Instalar Nuxt manualmente
+ManualInstallVideoTitle: Instalar a Nuxt Manualmente
 ---
 
 # Instalação
 
-Aqui, você vai encontrar informações sobre como configurar e iniciar um projeto Nuxt em 4 passos.
+Neste artigo, encontraremos informação sobre como configurar e executar um projeto de Nuxt dentro de 4 passos.
 
 ---
 
-## Online playground
+## Zona de Testes Virtuais
 
-Você pode divertir-se com o Nuxt de forma online, diretamente pelo CodeSandbox ou StackBlitz:
-:app-button[Divertir-se no CodeSandbox]{href=https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/ size="small" externalIcon}
-:app-button[Divertir-se no StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/stackblitz size="small" externalIcon}
+Podemos brincar com a Nuxt diretamente na CodeSandbox ou na StackBlitz:
+
+:app-button[Brincar na CodeSandbox]{href=https://codesandbox.io/s/github/nuxt/codesandbox-nuxt/tree/master/ size="small" externalIcon}
+:app-button[Brincar na StackBlitz]{href=https://stackblitz.com/github/nuxt/starter/tree/stackblitz size="small" externalIcon}
 
 ## Pré-requisitos
 
-- [node](https://nodejs.org) - _Nós recomendamos que você tenha a última versão LTS instalada_.
-- Um editor de texto, nós recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) ou [WebStorm](https://www.jetbrains.com/webstorm/)
+- [node](https://nodejs.org) - _recomendamos ter a ou a 16.x ou a 14.x instalada_.
+- Um editor de texto, recomendamos [VS Code](https://code.visualstudio.com/) com a extensão [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) ou [WebStorm](https://www.jetbrains.com/webstorm/)
 - Um terminal, nós recomendamos utilizar o [terminal integrado](https://code.visualstudio.com/docs/editor/integrated-terminal) do VS Code ou [terminal WebStorm](https://www.jetbrains.com/help/webstorm/terminal-emulator.html).
 
-## Usando create-nuxt-app
+## Usar a `create-nuxt-app`
 
-Para iniciar rapidamente, você pode utilizar [create-nuxt-app](https://github.com/nuxt/create-nuxt-app).
+Para iniciarmos rapidamente, podemos usar a [`create-nuxt-app`](https://github.com/nuxt/create-nuxt-app).
 
-Tenha certeza que você possui instalado o yarn, npx (incluido por padrão no npm v5.2+) ou npm (v6.1+).
+Precisamos de certificar-nos de que temos instalado as ferramentas, yarn, npx (incluída por padrão com a npm v5.2+) ou npm (v6.1+).
 
 ::code-group
-
 ```bash [Yarn]
 yarn create nuxt-app <project-name>
 ```
-
 ```bash [NPX]
 npx create-nuxt-app <project-name>
 ```
-
 ```bash [NPM]
 npm init nuxt-app <project-name>
 ```
-
+```bash [PNPM]
+pnpm create nuxt-app <project-name>
+```
 ::
 
-O terminal irá fazer algumas perguntas (nome, opções do Nuxt, framework de UI, TypeScript, linter, framework de testes, etc). Para encontrar mais detalhes sobre todas essas opções veja a [documentação create-nuxt-app](https://github.com/nuxt/create-nuxt-app/blob/master/README.md).
+O programa fazer-nos-á algumas perguntas (nome, opções da Nuxt, abstração de interface de utilizador, TypeScript, analisador de código, abstração de teste, etc). Para sabermos mais sobre todas as opções, podemos consultar a [documentação da `create-nuxt-app`](https://github.com/nuxt/create-nuxt-app/blob/master/README.md).
 
-Uma vez que todas as questões foram respondidas, será instalada todas as dependências. O próximo passo é navegar para a pasta do projeto e inicia-lo:
+Quando todas as perguntas forem respondidas, esta instalará todas as dependências. O passo seguinte é navegar para a pasta do projeto e iniciá-lo:
 
 ::code-group
-
 ```bash [Yarn]
 cd <project-name>
 yarn dev
 ```
-
 ```bash [NPM]
 cd <project-name>
 npm run dev
 ```
-
+```bash [PNPM]
+cd <project-name>
+pnpm dev
+```
 ::
 
-A aplicação agora estará rodando em [http://localhost:3000](http://localhost:3000). Parabéns!
+A aplicação está agora a ser executada em [http://localhost:3000](http://localhost:3000). Muito bem!
 
 ::alert{type="info"}
-Outra forma de iniciar o Nuxt é utilizando [CodeSandbox](https://template.nuxtjs.org) o qual é uma ótima maneira de iniciar rapidamente no Nuxt e/ou compartilhar o seu código com outras pessoas.
+Outra maneira de começar a usar a Nuxt é com o uso da [CodeSandbox](https://template.nuxtjs.org), que é uma excelente maneira de brincar rapidamente com a Nuxt e/ou partilhar o nosso código com outras pessoas.
 ::
 
-## Instalação manual
+## Instalação Manual
 
-Criar um projeto Nuxt do início vai necessitar apenas de um arquivo e uma pasta.
+A criação de um projeto de Nuxt a partir do zero requer apenas um ficheiro e um diretório.
 
-Nós vamos usar o terminal para criar os diretórios e arquivos, sinta-se livre para criar usando um editor de sua escolha.
+Utilizaremos o terminal para criar os diretórios e ficheiros, mas podemos criá-los com o uso do nosso editor de eleição.
 
-### Configurando o seu projeto
+### Configurar o nosso projeto
 
-Crie uma pasta vazia com o nome do seu projeto e navegue para dentro dele :
+Criaremos um diretório vazio com o nome do nosso projeto e navegaremos para ele:
 
 ```bash
 mkdir <project-name>
 cd <project-name>
 ```
 
-_Substitua `<project-name>` com o nome do seu projeto._
+_Devemos substituir `<project-name>` pelo nome do nosso projeto._
 
-Crie o arquivo `package.json` :
+Criaremos o ficheiro `package.json`:
 
 ```bash
 touch package.json
 ```
 
-Preencha o conteúdo do seu `package.json` com :
+Preencheremos o conteúdo do nosso `package.json` com:
 
 ```json{}[package.json]
 {
@@ -110,55 +111,55 @@ Preencha o conteúdo do seu `package.json` com :
 }
 ```
 
-`scripts` define os comandos do Nuxt que serão executados com o comando `npm run <command>` ou `yarn <command>`.
+`scripts` definem comandos da Nuxt que serão iniciados com o comando `npm run <command>` ou `yarn <command>`.
 
-#### **O que é o arquivo package.json ?**
+#### **O que é um ficheiro `package.json`?**
 
-O arquivo `package.json` é como o documento de identificação do seu projeto. Ele irá conter todas as dependências do projeto e muito mais. Se você não sabe o que é o arquivo `package.json`, nós recomendamos imensamente a leitura da documentação do [npm](https://docs.npmjs.com/creating-a-package-json-file).
+O ficheiro `package.json` é como o cartão de identificação do nosso projeto. Contém todas as dependências do projeto e muito mais. Se não soubermos o que é o ficheiro `package.json`, podemos dar uma leitura rápida da [documentação da npm](https://docs.npmjs.com/creating-a-package-json-file).
 
-### Instalando Nuxt
+### Instalar a Nuxt
 
-Uma vez que o `package.json` foi criado, adicione `nuxt` no seu projeto via `npm` or `yarn` utilizando um dos comandos abaixo:
+Uma vez que o `package.json` tenha sido criado, adicionamos a `nuxt` ao nosso projeto via `npm` ou `yarn` como abaixo:
 
 ::code-group
-
 ```bash [Yarn]
 yarn add nuxt
 ```
-
 ```bash [NPM]
 npm install nuxt
 ```
-
+```bash [PNPM]
+pnpm add nuxt --shamefully-hoist
+```
 ::
 
-Esse comando vai adicionar `nuxt` como uma dependência para o seu projeto e vai adiciona-lo no seu `package.json`. A pasta `node_modules` também será criada, é aonde todos os seus pacotes instalados e dependencias serão salvas.
+Este comando adicionará a `Nuxt` como uma dependência ao nosso projeto e adicionar-lo-á ao nosso `package.json`. O diretório `node_modules` também será criado, o qual é onde todos os nossos pacotes instalados e dependências serão armazenados.
 
 ::alert{type="info"}
 
-Um arquivo `yarn.lock` ou `package-lock.json` também será criado, o qual garante consistência e a compatibilidade das dependências instaladas no seu projeto.
+Um `yarn.lock` ou `package-lock.json` também é criado, garantindo uma instalação consistente e dependências compatíveis dos nossos pacotes instalados no nosso projeto.
 
 ::
 
-### Criando a sua primeira página
+### Criar a nossa primeira página
 
-Nuxt transforma todos arquivos `*.vue` dentro da pasta `pages` em rotas para a aplicação.
+A Nuxt transforma cada ficheiro `*.vue` dentro do diretório `pages` numa rota para a aplicação.
 
-Crie a pasta `pages` dentro do seu projeto :
+Criamos o diretório `pages` no nosso projeto:
 
 ```bash
 mkdir pages
 ```
 
-Então, crie um arquivo `index.vue` dentro da pasta `pages` :
+Depois, criamos um ficheiro `index.vue` dentro do diretório `pages`:
 
 ```bash
 touch pages/index.vue
 ```
 
-É importante que essa página seja nomeada `index.vue` dessa forma ela será a página principal que o Nuxt irá mostrar quando a aplicação abrir.
+É importante que esta página se chame `index.vue`, pois esta será a página inicial padrão que a Nuxt mostrará quando a aplicação abrir.
 
-Abra o arquivo `index.vue` no seu editor e adicione o seguinte conteúdo :
+Abrimos o ficheiro `index.vue` no nosso editor e adicionamos o seguinte conteúdo:
 
 ```html{}[pages/index.vue]
 <template>
@@ -166,56 +167,54 @@ Abra o arquivo `index.vue` no seu editor e adicione o seguinte conteúdo :
 </template>
 ```
 
-### Iniciando o projeto
+### Iniciar o projeto
 
-Inicie o seu projeto executando um dos seguintes comandos abaixo :
+Executamos o nosso projeto escrevendo um dos seguintes comandos no nosso terminal:
 
 ::code-group
-
 ```bash [Yarn]
 yarn dev
 ```
-
 ```bash [NPM]
 npm run dev
 ```
-
+```bash [PNPM]
+pnpm dev
+```
 ::
 
 ::alert{type="info"}
 
-Nós usamos o comando dev quando iniciamos a nossa aplicação no modo de desenvolvimento.
+Utilizamos o comando `dev` para executar a nossa aplicação em modo de desenvolvimento.
 
 ::
 
-A aplicação está agora rodando em **[http://localhost:3000](http://localhost:3000/)**.
+A aplicação está agora a ser executada em **[http://localhost:3000](http://localhost:3000/)**.
 
-Abra no seu navegador clicando no link do seu terminal e você deverá ver o texto "Hello world!"
-que nós copiamos no passo anterior.
+Abrimos a aplicação no nosso navegador clicando na hiperligação no nosso terminal e devemos ver o texto “Hello World” que copiámos no passo anterior.
 
 ::alert{type="info"}
 
-Quando iniciado o Nuxt no modo de desenvolvimento, ele estará escutando por mudanças nos arquivos dentro dos demais diretórios, então não há necessidade de reiniciar a aplicação quando por exemplo adicionar páginas novas.
+Quando iniciarmos a Nuxt no modo de desenvolvimento, esta ouvirá as alterações de ficheiros na maioria dos diretórios, pelo que não é necessário reiniciar a aplicação quando, por exemplo, adicionarmos novas páginas.
 
 ::
 
 ::alert{type="warning"}
 
-Quando você rodar o comando dev será criado uma pasta chamada `.nuxt`. Essa pasta deve ser ignorada
-pelo controle de versionamento. Você ignorar arquivos criando um arquivo `.gitignore` na raiz do projeto e adicionando .nuxt ao arquivo.
+Quando executarmos o comando `dev`, este criará uma pasta `.nuxt`. Esta pasta deve ser ignorada do controlo de versões. Podemos ignorar ficheiros criando um ficheiro `.gitignore` no nível da raiz e adicionando `.nuxt`.
 
 ::
 
-### Passo extra
+### Etapa de Bónus
 
-Crie uma pagina chamada `fun.vue` dentro da pasta `pages`.
+Criaremos uma página chamada `fun.vue` no diretório `pages`.
 
-Adicione um `<template></template>` e inclua um cabeçalho com uma frase engraçada dentro.
+Adicionaremos um `<template></template>` e incluímos um cabeçalho com uma frase engraçada no interior.
 
-Então, vá até o seu navegador e veja a sua nova página em **[localhost:3000/fun](http://localhost:3000/fun)**.
+Depois, iremos ao nosso navegador e veremos a nova página em **[localhost:3000/fun](http://localhost:3000/fun)**.
 
 ::alert{type="info"}
 
-Criar uma pasta `more-fun` e colocar um arquivo `index.vue` dentro, irá dar o mesmo resultado que criar um arquivo `more-fun.vue`.
+Criar um diretório chamado `more-fun` e colocar um ficheiro `index.vue` dentro dele dará o mesmo resultado que criar um ficheiro `more-fun.vue`.
 
 ::

--- a/content/pt/docs/1.get-started/2.routing.md
+++ b/content/pt/docs/1.get-started/2.routing.md
@@ -1,6 +1,6 @@
 ---
 title: Roteamento
-description: A maioria dos sítios da web têm mais que uma página. Por exemplo uma página inicial, uma página sobre, página de contacto etc. No sentido de exibir essas paginas nós precisamos de um Roteador.
+description: A maioria dos sítios da Web têm mais que uma página. Por exemplo, uma página inicial, uma página sobre, página de contacto etc. Para mostrar estas páginas precisamos de um roteador.
 category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/02_routing?fontsize=14&hidenavigation=1&theme=dark
 video: cKutrcn-hdE
@@ -8,46 +8,46 @@ video: cKutrcn-hdE
 
 # Roteamento
 
-A maioria dos sítios da web têm mais que uma página. Por exemplo uma página inicial, uma página sobre, página de contacto etc. No sentido de exibir essas paginas nós precisamos de um Roteador.
+A maioria dos sítios da Web têm mais que uma página. Por exemplo, uma página inicial, uma página sobre, página de contacto etc. Para mostrar estas páginas precisamos de um roteador.
 
 ---
 
-## Rotas automáticas
+## Rotas Automáticas
 
-A maioria dos websites irão ter mais que uma página (por exemplo página inicial, página sobre, formas de contato etc.). Para mostrar essas paginas nós precisamos de um Router. É aonde o `vue-router` entra. Quando se trabalha com aplicações Vue, você tem que iniciar o arquivo de configuração (exemplo `router.js`) e adicionar todas as rotas manualmente nele. O Nuxt gera automaticamente as configurações do `vue-router` para você, com base nos ficheiros de Vue dentro da pasta `pages`. Isso significa que você nunca mais terá que escrever as configurações do roteador! O Nuxt também oferece para você a separação automática de código para todas suas rotas.
+A maioria dos sítios da Web terão mais do que uma página (ou seja, uma página inicial, página sobre, uma página de contacto, etc). Para mostrar estas páginas, precisamos de um roteador. É aí que entra a `vue-router`. Quando trabalhamos com a aplicação de Vue, temos de definir um ficheiro de configuração (ou seja, `router.js`) e adicionar todas as nossas rotas manualmente. A Nuxt gera automaticamente a configuração da `vue-router` por nós, baseada nos nossos ficheiros `.vue` fornecidos dentro do diretório `pages`. Isto significa que nunca mais teremos de escrever uma configuração de roteador! A Nuxt também dá-nos a divisão automática de códigos para todas as nossas rotas.
 
-Em outras palavras, tudo o que você tem que fazer para ter uma rota na sua aplicação é criar ficheiros `.vue` dentro da pasta `pages`.
+Em outras palavras, tudo o que temos que fazer para ter roteamento na nossa aplicação é criar ficheiros `.vue` na pasta `pages`.
 
 ::alert{type="next"}
-Saiba mais sobre o [Roteamento](/docs/features/file-system-routing)
+Saber mais sobre o [Roteamento](/docs/features/file-system-routing).
 ::
 
 ## Navegação
 
-Para navegar entre as páginas da sua aplicação, você deve usar o componente [NuxtLink](/docs/features/nuxt-components#o-componente-nuxtlink). Esse componente é incorporado no Nuxt, portanto você não tem que importar ele assim como você faz com os outros componentes. É similar ao marcador `<a>` do HTML, exceto que ao invés de usar um `href="/about"` nós usamos `to="/about"`. Se você já usou `vue-router` antes, você pode pensar no componente `<NuxtLink>` como uma substituto do componente `<RouterLink>`.
+Para navegar entre as páginas da nossa aplicação, devemos utilizar o componente [`NuxtLink`](/docs/features/nuxt-components#o-componente-nuxtlink). Este componente é incluído com a Nuxt, pelo que não temos de o importar como fazemos com outros componentes. É semelhante ao marcador da HTML `<a>`, exceto que em vez de utilizar `href="/about"` utilizamos `to="/about"`. Se já utilizamos a `vue-router` antes, podemos pensar no `<NuxtLink>` como um substituto para o `<RouterLink>`.
 
-Uma simples ligação para a página `index.vue` dentro da sua pasta `pages`:
+Uma simples hiperligação para a página `index.vue` na nossa pasta `pages`:
 
 ```html{}[pages/index.vue]
 <template>
-  <NuxtLink to="/">Página inicial</NuxtLink>
+  <NuxtLink to="/">Home page</NuxtLink>
 </template>
 ```
 
-Para todas ligações para as páginas dentro do seu sítio, use `<NuxtLink>`. Se você tiver ligações para outros sítios na web você deve usar o marcador `<a>`. Para ter uma ideia consulte o exemplo abaixo:
+Para todas as hiperligações às páginas do nosso sítio, utilizamos `<NuxtLink>`. Se tivermos hiperligações a outros sítios da Web, devemos utilizar o marcador `<a>`. Veremos abaixo um exemplo:
 
 ```html{}[pages/index.vue]
 <template>
   <main>
-    <h1>Página Inicial</h1>
+    <h1>Home page</h1>
     <NuxtLink to="/about">
-      Sobre (ligação interna que pertence a aplicação do Nuxt)
+      About (internal link that belongs to the Nuxt App)
     </NuxtLink>
-    <a href="https://v2.nuxt.com">Ligação externa para outra página</a>
+    <a href="https://v2.nuxt.com">External Link to another page</a>
   </main>
 </template>
 ```
 
 ::alert{type="next"}
-Saiba mais sobre o [Componente NuxtLink](/docs/features/nuxt-components#o-componente-nuxtlink).
+Saber mais sobre o [componente `NuxtLink`](/docs/features/nuxt-components#o-componente-nuxtlink).
 ::

--- a/content/pt/docs/1.get-started/3.directory-structure.md
+++ b/content/pt/docs/1.get-started/3.directory-structure.md
@@ -1,86 +1,81 @@
 ---
-title: Estrutura de Diretórios
-description: A estrutura padrão de uma aplicação Nuxt oferece um excelente ponto de partida tanto para aplicações pequenas, quanto para aplicações grandes. Você está livre para organizar a sua aplicação da forma que desejar e criar outros diretórios conforme precisar.
+title: Estrutura do Diretório
+description: A estrutura predefinida da aplicação de Nuxt destina-se a fornecer um excelente ponto de partida para aplicações pequenas e grandes. Somos livres de organizar a nossa aplicação da maneira que quisermos e podemos criar outros diretórios se e quando precisarmos destes.
 category: get-started
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/01_get_started/03_directory_structure?fontsize=14&hidenavigation=1&theme=dark
 ---
 
-# Estrutura de Diretórios
+# Estrutura do Diretório
 
-A estrutura padrão de uma aplicação Nuxt oferece um excelente ponto de partida tanto para aplicações pequenas, quanto para aplicações grandes.
-Você está livre para organizar a sua aplicação da forma que desejar e criar outros diretórios conforme precisar.
+A estrutura predefinida da aplicação de Nuxt destina-se a fornecer um excelente ponto de partida para aplicações pequenas e grandes. Somos livres de organizar a nossa aplicação da maneira que quisermos e podemos criar outros diretórios se e quando precisarmos destes.
 
 ---
 
-Vamos criar os diretórios e ficheiros que ainda não existem no seu projeto.
+Criaremos os diretórios e ficheiros que ainda não existem no nosso projeto.
 
 ```bash
 mkdir components assets static
 touch nuxt.config.js
 ```
 
-Esses são os diretórios e os ficheiros principais que nós usamos quando estamos construindo uma aplicação Nuxt. Você vai encontrar uma explicação para cada um deles abaixo.
+Estes são os principais diretórios  e ficheiros que usamos ao construir uma aplicação de Nuxt. A explicação de cada um destes é apresentada a seguir.
 
 ::alert{type="info"}
-
-Criar diretórios com esses nomes ativa as funcionalidades no seu projeto Nuxt.
-
+A criação de diretórios com estes nomes ativa funcionalidades no nosso projeto de Nuxt.
 ::
 
 ## Diretórios
 
-### O diretório pages
+### O diretório `pages`
 
-O diretório `pages` contém as apresentações e rotas da sua aplicação.
-Conforme você aprendeu no último capítulo, Nuxt lê todos os arquivos `.vue` dentro da pasta e os utiliza para criar as rotas da aplicação.
+O diretório `pages` contém as visões e as rotas da nossa aplicação. Como aprendemos no último capítulo, a Nuxt lê todos os ficheiros `.vue` dentro deste diretório e utiliza-os para criar o roteador da aplicação.
 
 ::alert{type="next"}
-Aprender mais sobre o [diretório pages](/docs/directory-structure/pages)
+Saber mais sobre o [diretório `pages`](/docs/directory-structure/pages).
 ::
 
-### O diretório components
+### O diretório `components`
 
-O diretório `components` é aonde você vai colocar todos os seus componentes Vue.js os quais serão importados dentro das suas páginas.
+O diretório `components` é onde colocamos todos os componentes de Vue.js, os quais são depois importados para as nossas páginas.
 
-Com o Nuxt você pode criar os seus componentes e importar eles automaticamente dentro de seus ficheiros `.vue`, querendo dizer que não é mais necessário importar eles manualmente na secção de `script`.
-Nuxt examinará e importará eles automaticamente por você uma vez que "components" está definido como "true".
+Com a Nuxt podemos criar os nossos componentes e importá-los automaticamente para os nossos ficheiros `.vue`, o que significa que não é necessário importá-los manualmente na secção de programas (`scripts`). A Nuxt irá analisá-los e importá-los automaticamente para nós quando os componentes estivermos `components` definido como verdadeiro (`true`).
 
 ::alert{type="next"}
-Aprenda mais sobre o [diretório components](/docs/directory-structure/components)
+Saber mais sobre o [diretório `components`](/docs/directory-structure/components).
 ::
 
-### O diretório assets
+### O diretório `assets`
 
-O diretório `assets` contém seus ficheiros não compilados como folhas de estilo, imagens, ou fontes.
+O diretório `assets` contém os nossos recursos não compilados, como os nossos estilos, imagens, ou fontes.
 
 ::alert{type="next"}
-Aprenda mais sobre o [diretório assets](/docs/directory-structure/assets)
+Saber mais sobre o [diretório `assets`](/docs/directory-structure/assets).
 ::
 
-### O diretório static
+### O diretório `static`
 
-O diretório `static` é mapeado diretamente para a raiz do servidor e contém arquivos que precisam manter os seus nomes (por exemplo `robots.txt`) _ou_ semelhantes que não irão mudar (exemplo o favicon)
+O diretório `static` é mapeado diretamente para a raiz do servidor e contém ficheiros que devem manter os seus nomes (por exemplo, `robots.txt`) _ou_ provavelmente não mudarão (por exemplo, o ícone favorito).
 
 ::alert{type="next"}
-Aprenda mais sobre o [diretório static](/docs/directory-structure/static)
+Saber mais sobre o [diretório `static`](/docs/directory-structure/static)
 ::
 
-### O ficheiro nuxt.config.js
+### O ficheiro `nuxt.config.js`
 
-O ficheiro `nuxt.config.js` é o único ponto de configuração para o Nuxt. Se você quiser adicionar módulos ou sobrescrever as configurações padrão, esse é o lugar para aplicar as mudanças.
+O ficheiro `nuxt.config.js` é o único ponto de configuração da Nuxt. Se pretendermos adicionar módulos ou substituir as predefinições, este é o lugar onde aplicamos as alterações.
 
 ::alert{type="next"}
-Aprenda mais sobre o [ficheiro nuxt.config.js](/docs/directory-structure/nuxt-config)
+Saber mais sobre o [ficheiro `nuxt.config.js`](/docs/directory-structure/nuxt-config).
 ::
 
-### O ficheiro package.json
+### O ficheiro `package.json`
 
-O ficheiro `package.json` contém todas as dependências e scripts para a sua aplicação.
+O ficheiro `packages.json` contém todas as dependências (`dependencies`) e programas (`scripts`) para a nossa aplicação.
 
-## Mais sobre a estrutura de projeto
+## Mais informações sobre as estruturas do projeto
 
-Existem outros diretórios e ficheiros úteis, como [content](/docs/directory-structure/content), [layouts](/docs/directory-structure/layouts), [middleware](/docs/directory-structure/middleware), [modules](/docs/directory-structure/modules), [plugins](/docs/directory-structure/plugins) e [store](/docs/directory-structure/store). Como eles não são necessários para pequenas aplicações, eles não sào explicados aqui.
+Existem mais diretórios e ficheiros úteis, incluindo [`content`](/docs/directory-structure/content), [`layouts`](/docs/directory-structure/layouts), [`middleware`](/docs/directory-structure/middleware), [`modules`](/docs/directory-structure/modules), [`plugins`](/docs/directory-structure/plugins) e [`store`](/docs/directory-structure/store). Como não são necessárias para pequenas aplicações, não são abordadas neste artigo.
 
 ::alert{type="next"}
-Para aprender mais sobre todas as pastas em detalhes, sinta-se livre para ler [O guia de estrutura de diretórios](/docs/directory-structure/nuxt).
+Para aprendermos com detalhes sobre todos os diretórios, devemos ler o [livro Estrutura do Diretório](/docs/directory-structure/nuxt).
 ::

--- a/content/pt/docs/1.get-started/4.commands.md
+++ b/content/pt/docs/1.get-started/4.commands.md
@@ -1,19 +1,19 @@
 ---
-title: Comandos e Desdobramento
-description: O Nuxt oferece um conjunto de comandos úteis, tanto para fins de desenvolvimento como para produção.
+title: Comandos e Implantação
+description: A Nuxt vem com um conjunto de comandos úteis, tanto para fins de desenvolvimento como de produção.
 category: get-started
 video: hYdXzIGDlYA
 ---
 
-# Comandos e desdobramento
+# Comandos e Implantação
 
-O Nuxt oferece um conjunto de comandos úteis, tanto para fins de desenvolvimento como para produção.
+A Nuxt vem com um conjunto de comandos úteis, tanto para fins de desenvolvimento como de produção.
 
 ---
 
-## Usando no package.json
+## Usar no `package.json`
 
-Você deve ter esses comandos no seu `package.json`:
+Devemos ter estes comandos no nosso `package.json`:
 
 ```json
 "scripts": {
@@ -24,52 +24,49 @@ Você deve ter esses comandos no seu `package.json`:
 }
 ```
 
-Você pode executar os seus comandos via `yarn <command>`ou `npm run <command>` (exemplo: `yarn dev` / `npm run dev`).
+Podemos executar os nossos comandos via `yarn <command>`ou `npm run <command>` (exemplo: `yarn dev` / `npm run dev`).
 
-## Ambiente de desenvolvimento
+## Ambiente de Desenvolvimento
 
-Para iniciar o Nuxt em modo de desenvolvimento com a [substituição instantânea de módulo](https://webpack.js.org/concepts/hot-module-replacement/) em `http://localhost:3000`:
+Para executar a Nuxt em modo de desenvolvimento com a [substituição de módulo instantânea](https://webpack.js.org/concepts/hot-module-replacement/) em `http://localhost:3000`:
 
 ::code-group
-
 ```bash [Yarn]
 yarn dev
 ```
-
 ```bash [NPM]
 npm run dev
 ```
-
 ::
 
-## Lista de comandos
+## Lista de Comandos
 
-Você pode executar diferentes comandos dependendo do [alvo](/docs/features/deployment-targets):
+Podemos executar comandos diferentes consoante o [destino](/docs/features/deployment-targets):
 
-### target: `server` (valor padrão)
+### destino: `server` (valor predefinido)
 
-- **nuxt dev** - Inicia o servidor de desenvolvimento.
-- **nuxt build** - Constrói e otimiza a sua aplicação com webpack para produção.
-- **nuxt start** - Inicia o servidor de produção (depois de rodar `nuxt build`). Use ele para hospedagem de Node.js como Heroku, Digital Ocean, etc.
+- **`nuxt dev`** — Executar o servidor de desenvolvimento.
+- **`nuxt build`** — Construir e otimizar a nossa aplicação com a Webpack para produção.
+- **`nuxt start`** — Iniciar o servidor de produção (após executar `nuxt build`). O utilizámos para a hospedagem de Node.js, como a Heroku, a Digital Ocean, etc.
 
-### target: `static`
+### destino: `static`
 
-- **nuxt dev** - Inicia o servidor de desenvolvimento.
-- **nuxt generate** - Constrói a aplicação (se necessário), gera todas as rotas como um arquivo HTML e exporta estaticamente para o diretório `dist/` (usado para hospedagem estática).
-- **nuxt start** - Serve o diretório `dist/` como sua hospedagem estática faria (Netlify, Vercel, Surge, etc), ótimo para testar antes do desdobramento.
+- **`nuxt dev`** — Executar o servidor de desenvolvimento.
+- **`nuxt generate`** — Construir a aplicação (se necessário), gerar cada rota como um ficheiro `.html` e exportar estaticamente para o diretório `dist/` (usado para a hospedagem estática).
+- **`nuxt start`** — Servir o diretório `dist/` como a nossa hospedagem estática faria (Netlify, Vercel, Surge, etc), ótimo para testar antes de implantar.
 
-## Inspeção da configuração do Webpack
+## Inspeção da Configuração da Webpack
 
-Você pode inspecionar a configuração do webpack usada pelo Nuxt para construir o projeto (similar ao [vue inspect](https://cli.vuejs.org/guide/webpack.html#inspecting-the-project-s-webpack-config)).
+Podemos inspecionar a configuração da Webpack utilizada pela Nuxt para construir o projeto (semelhante à [inspeção de vue](https://cli.vuejs.org/guide/webpack.html#inspecting-the-project-s-webpack-config)).
 
-- **nuxt webpack [query...]**
+- **`nuxt webpack [query...]`**
 
 **Argumentos:**
 
-- `--name`: Nome do pacote a inspecionar. (client, server, modern)
-- `--dev`: Inspeciona a configuração do webpack para modo de desenvolvimento
-- `--depth`: Inspeção profunda. O valor padrão é 2 para evitar saída verbosa.
-- `--no-colors`: Desativa as cores ANSI (desativado por padrão quando o TTY não está disponível ou quando estiver canalizando para um ficheiro)
+- `--name`: Nome do pacote a inspecionar (cliente, servidor, moderno).
+- `--dev`: Inspecionar a configuração da Webpack para o modo de desenvolvimento.
+- `--depth`: Profundidade de inspeção. A predefinição é 2 para evitar a saída detalhada.
+- `--no-colors`: Desativar as cores do Instituto Nacional Americano de Normas (ANSI) (desativadas por predefinição quando a Máquina de Escrever À Distância (TTY) não está disponível ou ao se canalizar para um ficheiro).
 
 **Exemplos:**
 
@@ -83,51 +80,45 @@ Você pode inspecionar a configuração do webpack usada pelo Nuxt para construi
 - `nuxt webpack module rules loader=vue-`
 - `nuxt webpack module rules "loader=.*-loader"`
 
-## Desdobramento de produção
+## Implantação da Produção
 
-Nuxt deixa você escolher entre os desdobramentos de servidor ou estático.
+A Nuxt permite-nos escolher entre as implantações de Servidor ou Estática.
 
-### Desdobramento de servidor
+### Implantação de Servidor
 
-Para desdobrar uma aplicação renderizada no lado do servidor (SSR) nós usamos `target: 'server'`, onde `server` é o valor padrão.
+Para implantar uma aplicação de interpretação do lado do servidor (SSR) usamos `target: 'server'`, onde `'server'` é o valor predefinido:
 
 ::code-group
-
 ```bash [Yarn]
 yarn build
 ```
-
 ```bash [NPM]
 npm run build
 ```
-
 ::
 
-Nuxt criará um diretório `.nuxt` com tudo pronto para ser desdobrado na sua hospedagem de.
+A Nuxt criará um diretório `.nuxt` com tudo dentro, pronto para ser implantado na nossa hospedagem de servidor:
 
 ::alert{type="info"}
-Nós recomendamos adicionar `.nuxt` ao `.npmignore` ou `.gitignore`.
+Recomendamos colocar o `.nuxt` no `.npmignore` ou `.gitignore`.
 ::
 
-Uma vez que sua aplicação está construída você pode usar o comando `start` para ver a versão de produção da sua aplicação.
+Uma vez que a nossa aplicação esteja construída, podemos usar o comando `start` para ver uma versão de produção da nossa aplicação:
 
 ::code-group
-
 ```bash [Yarn]
 yarn start
 ```
-
 ```bash [NPM]
 npm run start
 ```
-
 ::
 
-### Desdobramento estático (Pré-renderizado)
+### Implantação Estática (Pré-interpretada)
 
-O Nuxt dá para você habilidade de hospedar a sua aplicação web em qualquer hospedagem estática.
+A Nuxt dá-nos a possibilidade de hospedar a nossa aplicação da Web em qualquer hospedagem estática.
 
-Para desdobrar um sitio estático gerado, certifique-se de ter o `target: 'static'` dentro do seu ficheiro `nuxt.config.js` (para versões do Nuxt maiores ou igual a 2.13):
+Para implantar um sítio gerado de maneira estática, precisamos ter certeza de que temos `target: 'static'` no nosso `nuxt.config.js` (para Nuxt >= 2.13):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -136,47 +127,45 @@ export default {
 ```
 
 ::code-group
-
 ```bash [Yarn]
 yarn generate
 ```
-
 ```bash [NPM]
 npm run generate
 ```
-
 ::
 
-O Nuxt criará um diretório `.nuxt` com tudo pronto para ser hospedado em um serviço de hospedagem de sítios estáticos.
+A Nuxt criará um diretório `dist/` com tudo dentro, pronto para ser implantado num serviço de hospedagem estática.
 
-A partir da versão 2.13 do Nuxt, existe um rastreador instalado que agora rastreará seus marcadores de ligação e gerará suas rotas baseadas naquelas ligações quando estiver usando o comando `nuxt generate`.
+::alert{type="info"}
+Recomendamos colocar `dist/` no `.npmignore` ou `.gitignore`.
+::
+
+Desde a versão 2.13 da Nuxt, existe um rastreador instalado que agora rastreará os nossos marcadores de hiperligações e gerará nossas rotas quando usarmos o comando `nuxt generate` baseado nestas hiperligações.
 
 ::alert{type="warning"}
-**Aviso:** Rotas dinâmicas são ignoradas pelo comando `generate` quando estiver usando versões do Nuxt menores ou igual a 2.12: [API de Configuração de `generate`](/docs/configuration-glossary/configuration-generate)
+**Aviso:** As rotas dinâmicas são ignoradas pelo comando `generate` quando utilizamos Nuxt <= v2.12: [API de Configuração de `generate`](/docs/configuration-glossary/configuration-generate)
 ::
 
 ::alert{type="info"}
-Quando estiver gerando a sua aplicação web com o `nuxt generate`, [o contexto](/docs/internals-glossary/context) dado para [asyncData](/docs/features/data-fetching#async-data) e [fetch](/docs/features/data-fetching#o-gatilho-fetch) não terá `req` e `res`.
+Quando gerarmos a nossa aplicação da Web com `nuxt generate`, [o contexto](/docs/internals-glossary/context) dado a [`asyncData`](/docs/features/data-fetching#async-data) e [`fetch`](/docs/features/data-fetching#a-função-gatilho-fetch) não terá `req` e `res`.
 ::
 
-#### **Falha sobre erro**
+#### **Falha no Erro**
 
-Para retornar um código de estado diferente de zero quando um erro de página for encontrado e permitir o CI/CD falhar o desdobramento ou a construção, você pode usar o argumento `--fail-on-error`.
+Para retornar um código de estado diferente de zero quando um erro de página é encontrado e deixar a integração contínua e entrega contínua falhar na implantação ou construção, podemos usar o argumento `--fail-on-error`:
 
 ::code-group
-
 ```bash [Yarn]
 yarn generate --fail-on-error
 ```
-
 ```bash [NPM]
 npm run generate --fail-on-error
 ```
-
 ::
 
-## Qual é o próximo?
+## O Que Se Segue?
 
 ::alert{type="next"}
-Leia o nosso [Guia de Desdobramentos](/deployments) para encontrar exemplos de desdobramentos em hospedeiros populares.
+Ler os [Guias de Implantação](/deployments) para encontrar exemplos de implantações nos hospedeiros populares.
 ::

--- a/content/pt/docs/1.get-started/5.conclusion.md
+++ b/content/pt/docs/1.get-started/5.conclusion.md
@@ -1,27 +1,27 @@
 ---
 title: Conclusão
-description: Parabéns você acabou de criar a sua primeira aplicação Nuxt e você agora deve se considerar um Nuxter. Mais existe ainda muita coisa para aprender e muito mais que você pode fazer com o Nuxt. Aqui temos algumas recomendações.
+description: Parabéns, já criámos a nossa primeira aplicação de Nuxt e já nos podemos considerar Nuxters. Mas existe muito mais para aprender e muito mais para fazer com a Nuxt. Eis algumas recomendações.
 category: get-started
 ---
 
 # Conclusão
 
-Parabéns você acabou de criar a sua primeira aplicação Nuxt e você agora deve se considerar um Nuxter. Mais existe ainda muita coisa para aprender e muito mais que você pode fazer com o Nuxt. Aqui temos algumas recomendações.
+Parabéns, já criámos a nossa primeira aplicação de Nuxt e já nos podemos considerar Nuxters. Mas existe muito mais para aprender e muito mais para fazer com a Nuxt. Eis algumas recomendações.
 
 ---
 
 ::alert{type="next"}
-Dê uma olhada no [Livro de conceitos](../concepts/views)
+Consultar o [livro de Conceitos](../concepts/views).
 ::
 
 ::alert{type="next"}
-Trabalhando com [asyncData](/docs/features/data-fetching#async-data)
+Trabalhar com a [`asyncData`](/docs/features/data-fetching#async-data).
 ::
 
 ::alert{type="next"}
-Escolhendo entre os diferentes [modos de renderização](/docs/features/rendering-modes)
+Escolher entre diferentes [Modos de Interpretação](/docs/features/rendering-modes).
 ::
 
 ::alert{type="star"}
-Você têm gostado do Nuxt? não se esqueça de dar uma [estrela no nosso projeto](https://github.com/nuxt/nuxt) on GitHub
+Se gostámos da Nuxt até agora, não devemos esquecer de [marcar o projeto com uma estrela](https://github.com/nuxt/nuxt) na GitHub.
 ::

--- a/content/pt/docs/1.get-started/6.upgrading.md
+++ b/content/pt/docs/1.get-started/6.upgrading.md
@@ -1,16 +1,16 @@
 ---
-title: Atualizando
-description: Atualizar o Nuxt é rápido, mas tem mais coisas envolvidas que o seu package.json
+title: Atualização
+description: A atualização da Nuxt é rápida, mas mais complexa do que atualizar o nosso `package.json`
 category: get-started
 ---
 
-# Atualizando
+# Atualização
 
-Atualizar o Nuxt é rápido, mas tem mais coisas envolvidas que o seu package.json
+A atualização da Nuxt é rápida, mas mais complexa do que atualizar o nosso `package.json`
 
 ---
 
-Se você estiver atualizando para Nuxt v2.14 e você quer usar hospedagem estática então você precisa adicionar [`target:static`](/docs/features/deployment-targets#hospedagem-estática) no seu arquivo nuxt.config.js para conseguir gerar o comando e funcionar apropriadamente.
+Se estivermos atualizando para Nuxt v2.14 e quisermos usar a hospedagem estática, então precisaremos adicionar [`target:static`](/docs/features/deployment-targets#hospedagem-estática) ao nosso ficheiro `nuxt.config.js` para o comando `generate` funcionar corretamente:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -18,23 +18,23 @@ export default {
 }
 ```
 
-## Iniciando
+## Começar
 
-1. Olhe a [notas de lançamento](/releases) para a versão que você deseja atualizar, e valide se existem instruções adicionais para aquela release em particular.
-2. Atualize a versão especificada para o pacote `nuxt` no seu arquivo `package.json`.
+1. Consultar as [notas de lançamento](/releases) da versão que pretendemos atualizar para ver se existem instruções adicionais para essa versão específica.
+2. Atualizar a versão especificada para o pacote `nuxt` no nosso ficheiro `package.json`.
 
-Após esta etapa, as instruções variam dependendo se você está usando Yarn ou npm. _[Yarn] (https://yarnpkg.com/en/docs/usage) é o gerenciador de pacotes preferido para trabalhar com Nuxt, pois é a ferramenta de desenvolvimento que os testes foram escritos ._
+Depois deste passo, as instruções variam consoante estejamos a utilizar a Yarn ou a npm. _[Yarn] (https://yarnpkg.com/en/docs/usage) é o gestor de pacote preferido para trabalhar com a Nuxt, uma vez que é a ferramenta de desenvolvimento para a qual os testes foram escritos._
 
 ## Yarn
 
-3. remova o arquivo `yarn.lock`
-4. remova a pasta `node_modules`
-5. Execute o comando `yarn`
-6. Após a instalação ser concluída e você ter executado seus testes, considere atualizar também outras dependências. O comando `yarn outdated` pode ser usado para isso.
+1. Remover o ficheiro `yarn.lock`
+2. Remover o diretório `node_modules`
+3. Executar o comando `yarn`
+4. Depois da instalação ter sido concluída e termos efetuado os nossos testes, temos de considerar a atualização de outras dependências também. O comando `yarn outdated` pode ser usado.
 
 ## npm
 
-3. remova o arquivo `package-lock.json`
-4. remova o diretório `node_modules`
-5. Execute o comando `npm install`
-6. Após a instalação ser concluída e você ter executado seus testes, considere atualizar também outras dependências. O comando `npm outdated` pode ser usado.
+1. Remover o ficheiro`package-lock.json`
+2. Remover o diretório `node_modules`
+3. Executar o comando `npm install`
+4. Depois da instalação ter sido concluída e termos efetuado os nossos testes, temos de considerar a atualização de outras dependências também. O comando `npm outdated` pode ser usado.

--- a/content/pt/docs/2.concepts/index.md
+++ b/content/pt/docs/2.concepts/index.md
@@ -1,4 +1,5 @@
 ---
+title: Conceitos
 navigation:
   collapse: true
   redirect: /docs/concepts/views


### PR DESCRIPTION
In this pull request, I am updating the translated content inside the `get-started` folder. This update consists in various grammar improvements and in the application of more descriptive words.

I also decided to signal progress and the desire to update the contents of the next folder by setting the `title: Conceitos` property in the `concepts/index.md` file.

I hope that this request to update the repository finds you in good health, and that this same request is combined with the main branch as soon as possible so that I can move forward more quickly with the rest.

Not only that, but I want to start translating the official Nuxt 3 documentation soon. I don't want to do it without first connecting the language used to communicate Nuxt 2 knowledge with Nuxt 3, and consequently updating the content of the Nuxt 2 documentation.