### PR TITLE
docs(pt): update content inside `directory-structure` folder

### DIFF
--- a/content/pt/docs/4.directory-structure/1.nuxt.md
+++ b/content/pt/docs/4.directory-structure/1.nuxt.md
@@ -1,23 +1,23 @@
 ---
-title: O diretório de construção do Nuxt
-description: O diretório .nuxt é o chamado "diretório de construção (build)". Ele é dinamicamente gerado e escondido por padrão. Dentro do diretório você pode encontrar ficheiros gerados automaticamente sempre que nuxt dev é usado ou seus artefactos de construção sempre que nuxt build é usado.
+title: Diretório de Construção da Nuxt
+description: O diretório de construção da Nuxt é gerado dinamicamente e oculto por predefinição. No diretório, podemos encontrar ficheiros gerados automaticamente quando usamos o comando de desenvolvimento ou os nossos artefactos de construção quando usamos o comando de construção.
 navigation.title: .nuxt
 category: directory-structure
 ---
 
-# O diretório de construção do Nuxt
+# Diretório de Construção da Nuxt
 
-O diretório `.nuxt` é o chamado _diretório de construção (build)_. Ele é dinamicamente gerado e escondido por padrão. Dentro do diretório você pode encontrar ficheiros gerados automaticamente sempre que `nuxt dev` é usado ou seus artefactos de construção sempre que `nuxt build` é usado. A modificação desses ficheiros é uma grande forma de depuração mas lembre que eles são ficheiros gerados e uma vez que você executar o comando `dev` ou `build` novamente, qualquer coisa que foi guardada aqui será regenerada.
+O diretório `.nuxt` é o chamado _diretório de construção_. É gerado dinamicamente e oculto por padrão. No diretório, podemos encontrar os ficheiros gerados automaticamente quando utilizamos o `nuxt dev` ou os nossos artefactos de construção quando utilizamos o `nuxt build`. Modificar esses ficheiros é ótimo para depuração, mas devemos lembrar que esses são ficheiros gerados e uma vez que executarmos o comando `dev` ou `build` novamente, qualquer coisa guardada neste diretório será gerada novamente.
 
 ---
 
 ::alert{type="warning"}
-O diretório `.nuxt` não deve ser enviado para o seu sistema de controle de versão e deve ser ignorado através do seu `.gitignore` já que ele será gerado automaticamente quando você executar o comando `nuxt dev` ou `nuxt build`.
+O diretório `.nuxt` não deve ser submetido ao nosso sistema de controlo de versão e deve ser ignorado através do nosso `.gitignore`, pois será gerado automaticamente ao executar `nuxt dev` ou `nuxt build`.
 ::
 
-### A propriedade buildDir
+### A Propriedade `buildDir`
 
-Por padrão, várias ferramentas assumem que `.nuxt` é um diretório oculto, pelo seu nome começar com um ponto. Você pode usar a opção `buildDir` para previr isso. Se você mudar o nome lembre de adicionar o novo nome dentro do seu ficheiro `.gitignore`.
+Por padrão, muitas ferramentas assumem que `.nuxt` é um diretório oculto, porque o seu nome começa com um ponto. Podemos usar a opção `buildDir` para evitar isto. Se alterarmos o nome, devemos lembrar-nos de adicionar o novo nome ao nosso ficheiro `.gitignore`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -25,22 +25,22 @@ export default {
 }
 ```
 
-### Dentro da pasta .nuxt:
+### Na Pasta `.nuxt`:
 
-- O ficheiro `router.js` é o ficheiro de roteador gerado que o Nuxt gera por você quando você coloca ficheiros `.vue` dentro da pasta `pages`. Você pode usar este ficheiro para fazer depuração para quando você quiser procurar quais rotas são geradas para o `vue-router` e encontrar os nomes de uma rota específica.
-- O `route.scrollBehavior.js` o qual é o seu comportamento de rolagem do roteador (Router ScrollBehavior)
-- A pasta de componentes tem todos os seus componentes do Nuxt tais como `NuxtChild` e NuxtLink. Ele também contém o `nuxt-build-indicator` o qual é a página que vemos quando sua aplicação está construindo e `nuxt-loading` o qual é seu componente de carregamento que é visto quando estamos esperando a sua página carregar. Você também encontrará a página nuxt-error aqui dentro a qual contém a página de erro padrão do Nuxt.
-- A pasta de `mixins` tem os ficheiros necessários para o método `$fetch` do Nuxt.
-- A pasta de `views` contém o modelo (template) da sua aplicação e sua página de erro do servidor.
-- A app.js é o ficheiro principal da sua aplicação.
-- O ficheiro `client.js` é o ficheiro do cliente necessário para tudo que acontece no lado do cliente.
-- O ficheiro vazio é intencionalmente deixado vazio para apelidos não operacionais
-- O ficheiro `index.js` molda sua aplicação.
-- O `loading.html` é o ficheiro que é usado quando a página está carregando.
-- O ficheiro `middleware` é onde o seu intermediário é conservado
-- O ficheiro `server.js` é todo código que é executado no servidor
-- As `utilities` contém as utilidades que o Nuxt precisa para ele funcionar.
+- O ficheiro `router.js` é o ficheiro roteador que a Nuxt gera para nós quando colocamos ficheiros `.vue` na pasta das páginas (`pages/`). Podemos usar este ficheiro para depuração quando queremos ver que rotas são geradas para a `vue-router` e descobrir os nomes duma rota específica.
+- O `route.scrollBehavior.js` que é o ficheiro que define o comportamento de deslocamento do nosso roteador.
+- A pasta dos componentes (`components/`) contém todos os nossos componentes de Nuxt, como `NuxtChild` e o `NuxtLink`. Também contém o `nuxt-build-indicator` que é a página que vemos quando a nossa aplicação está em construção e o `nuxt-loading` que é o nosso componente de carregamento visto quando estamos à espera da página ser carregada. Também encontraremos no interior desta pasta a página `nuxt-error`, que contém a página de erro predefinida da Nuxt.
+- A pasta das misturas (`mixins/`) contém os ficheiros necessários para o método `$fetch` da Nuxt.
+- A pasta das visões (`views/`) contém o nosso modelo de marcação de hipertexto de aplicação e a nossa página de erro do servidor.
+- O `app.js` é o ficheiro principal da nossa aplicação.
+- O ficheiro `client.js` é o nosso ficheiro cliente necessário para tudo o que acontece do lado do cliente.
+- O ficheiro vazio é intencionalmente deixado vazio para os pseudónimos não operacionais.
+- O ficheiro `index.js` inicia a nossa aplicação.
+- O `loading.html` é o ficheiro utilizado quando a página é carregada.
+- O ficheiro intermediário (`middleware`) é onde o nosso intermediário é guardado.
+- O ficheiro `server.js` é todo código executado no servidor.
+- Os utilitários (`utilities`) contêm os utilitários que a Nuxt precisa para funcionar.
 
-### Desdobrando
+### Implantar
 
-A pasta `.nuxt` é parte dos ficheiros necessários para desdobrar a sua aplicação SSR. Ela não é necessário para desdobrar a sua aplicação Nuxt estática porque usamos a pasta `dist` para isso.
+A pasta `.nuxt` faz parte dos ficheiros necessários para implantar a nossa aplicação interpretada do lado do servidor (`ssr`). No entanto, esta não é necessária para implantar a nossa aplicação estática de Nuxt, pois usamos a pasta `dist` para isto.

--- a/content/pt/docs/4.directory-structure/10.plugins.md
+++ b/content/pt/docs/4.directory-structure/10.plugins.md
@@ -1,28 +1,29 @@
 ---
-title: O diretório plugins
+title: Diretório de Extensões
 navigation.title: plugins
-description: O diretório plugins contém seus plugins escritos em JavaScript que você deseja executar antes da instanciação da raiz da aplicação Vue.js.
+description: O diretório de extensões contém as nossas extensões de JavaScript que queremos executar antes de instanciar a raiz da aplicação de Vue.js.
 category: directory-structure
 csb_link_plugins_client: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/12_plugins_client?fontsize=14&hidenavigation=1&theme=dark
 csb_link_plugins_external: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/12_plugins_external?fontsize=14&hidenavigation=1&theme=dark
 csb_link_plugins_custom: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/12_plugins_custom_plugin?fontsize=14&hidenavigation=1&theme=dark
 csb_link_plugins_vue: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/12_plugins_vue?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório plugins
 
-O diretório `plugins` contém seus plugins escritos em JavaScript que você deseja executar antes da instanciação da raiz da aplicação Vue.js.
+# Diretório de Extensões
+
+O diretório `plugins` contém as nossas extensões de JavaScript que queremos executar antes de instanciar a raiz da aplicação de Vue.js.
 
 ---
 
 ![](/img/docs/plugins.svg)
 
-Este é o lugar para adicionar os plugins do Vue e injetar funções ou constantes. Toda vez que você precisar usar o `Vue.use()`, você deve criar um ficheiro dentro de `plugins/` e adicionar seu caminho ao `plugins` dentro do `nuxt.config.js`.
+É nesta pasta onde adicionamos as extensões de Vue e injetamos as funções ou constantes. Toda a vez que precisarmos utilizar `Vue.use()`, devemos criar um ficheiro em `plugins/` e adicionar o seu caminho na propriedade `plugins` no `nuxt.config.js`:
 
-## Pacotes externos
+## Pacotes Externos
 
-Você pode querer usar pacotes/módulos externos dentro da sua aplicação (um grande exemplo é o [axios](https://axios.nuxtjs.org/)) para fazer requisições HTTP para ambos servidor e cliente.
+Podemos querer utilizar pacotes ou módulos externos na nossa aplicação (um ótimo exemplo é [`axios`](https://axios.nuxtjs.org)) para fazer requisições de protocolo de hipertexto tanto para o servidor quanto para o cliente.
 
-Primeiro, instale ele via npm ou yarn.
+Primeiro, o instalamos através de `npm` ou `yarn`:
 
 ::code-group
 ```bash [Yarn]
@@ -33,7 +34,7 @@ npm install @nuxtjs/axios
 ```
 ::
 
-Você pode configurar por exemplo os intercetores para reagir a possíveis erros da chamadas da sua API através da aplicação. Dentro deste exemplo nós redirecionamos o usuário para uma página de erro personalizada chamada desculpa (sorry) quando nós recebemos um estado de erro 500 por parte da nossa API.
+Podemos configurar, por exemplo, os intercetores da `axios` para reagir a possíveis erros das suas chamadas de interface de programação de aplicação em toda a aplicação. Neste exemplo, redirecionamos o utilizador para uma página de erro personalizada chamada `sorry` quando recebemos um erro de estado `500` da nossa interface de programação de aplicação:
 
 ```js{}[plugins/axios.js]
 export default function ({ $axios, redirect }) {
@@ -45,7 +46,7 @@ export default function ({ $axios, redirect }) {
 }
 ```
 
-Por último mas não menos importante, adicionar o módulo e o recentemente criado plugin à configuração do projeto.
+Por último, mas não menos importante, adicionamos o módulo e a extensão recém criada à configuração do projeto:
 
 ```js{}[nuxt.config.js]
 module.exports = {
@@ -54,7 +55,7 @@ module.exports = {
 }
 ```
 
-Depois podemos usar ele diretamente dentro do seu componentes de página:
+Depois, podemos utilizá-la diretamente nos componentes da nossa página:
 
 ```js{}[pages/index.vue]
 <template>
@@ -71,7 +72,7 @@ export default {
 </script>
 ```
 
-Uma outra maneira de usar o `axios` sem instalar o módulo é importando `axios` diretamente dentro da tag `<script>`.
+Outra maneira de utilizar a `axios` sem instalar o módulo é importando a `axios` diretamente no marcador `<script>`:
 
 ```js{}[pages/index.vue]
 <script>
@@ -87,21 +88,21 @@ export default {
 ```
 
 ::alert{type="info"}
-Se você receber um erro _Cannot use import statement outside a module (Você não pode usar a declaração de importação fora de um módulo)_, você pode precisar adicionar o seu pacote à opção `build` > `transpile` dentro do `nuxt.config.js` para o carregador do webpack tornar o seu plugin disponível.
+Se recebermos um erro `cannot use import statement outside a module`, podemos precisar adicionar o nosso pacote à opção `build` > `transpile` no `nuxt.config.js` para o carregador da Webpack disponibilizar a nossa extensão.
 ::
 
 ```js{}[nuxt.config.js]
 build: {
-  // Você pode estender a configuração do webpack aqui
+  // Podemos estender a configuração da Webpack neste objeto.
   transpile: ['npm-package-name'],
 },
 ```
 
-## Plugins de Vue
+## Extensões da Vue
 
-Se você quiser usar plugins do vue, como [v-tooltip](https://akryum.github.io/v-tooltip) para exibir dicas da ferramenta (tooltips) dentro da sua aplicação, nós precisamos configurar o plugin antes do lançamento da aplicação.
+Se quisermos usar extensões de Vue, como a [`v-tooltip`](https://akryum.github.io/v-tooltip) para exibir dicas de ferramentas na nossa aplicação, precisamos configurar a extensão antes de iniciar a aplicação.
 
-Primeiro, nós precisamos instalar ele
+Primeiro, precisamos de instalá-la:
 
 ::code-group
 ```bash [Yarn]
@@ -112,7 +113,7 @@ npm install v-tooltip
 ```
 ::
 
-Depois criamos o ficheiro `plugins/vue-tooltip.js`
+Depois criamos o ficheiro `plugins/vue-tooltip.js`.
 
 ```js{}[plugins/vue-tooltip.js]
 import Vue from 'vue'
@@ -121,9 +122,9 @@ import VTooltip from 'v-tooltip'
 Vue.use(VTooltip)
 ```
 
-### A propriedade plugins
+### A Propriedade `plugins`
 
-Então nós adicionamos o caminho do ficheiro dentro a chave `plugins` do nosso `nuxt.config.js`. A propriedade plugins permite você adicionar plugins do Vue.js à sua aplicação principal. Todos os caminhos definidos dentro da propriedade `plugins` serão importados antes da inicialização da aplicação principal.
+Depois adicionamos o caminho do ficheiro na chave `plugins` do nosso `nuxt.config.js`. A propriedade `plugins` permite-nos adicionar extensões de Vue facilmente à nossa aplicação principal. Todos os caminhos definidos na propriedade `plugins` serão importados antes de inicializar a aplicação principal:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -131,9 +132,9 @@ export default {
 }
 ```
 
-### Plugins do ES6
+### Extensões de ECMAScript 6
 
-Se o plugin está localizado dentro do `node_modules` e exporta um módulo ES6, você pode precisar adicionar ele à opção de construção `transpile`:
+Se a extensão estiver localizada em `node_modules` e exportar um módulo de ECMAScript 6, podemos precisar adicioná-la à opção de construção (compilação) `transpile`:
 
 ```js{}[nuxt.config.js]
 module.exports = {
@@ -143,15 +144,15 @@ module.exports = {
 }
 ```
 
-Você pode recorrer a documentação da [configuração do build](/docs/configuration-glossary/configuration-build#transpile) para saber mais sobre a opção build.
+Podemos consultar a [documentação da configuração da construção (compilação)](/docs/configuration-glossary/configuration-build#transpile) por mais opções de construção.
 
-## Apenas no lado do cliente ou servidor
+## Só do Lado do Cliente ou do Servidor
 
-Alguns plugins podem funcionar apenas dentro do browser por causa da falta suporte ao SSR.
+Algumas extensões podem funcionar apenas no navegador porque não têm suporte a interpretação do lado do servidor.
 
-### Nomear de maneira convencional o plugin
+### Convenção de Nomeação de Extensão
 
-Se é suposto um plugin ser executado apenas no lado do cliente ou servidor, `.client.js` ou `.server.js` podem ser aplicados como uma extensão do ficheiro do plugin. O ficheiro será automaticamente incluído apenas no respetivo lado (do cliente ou servidor).
+Se é suposto executar uma extensão apenas no lado do cliente ou do servidor, `.client.js` ou `.server.js` pode ser aplicado como uma extensão do ficheiro da extensão. O ficheiro será automaticamente incluído apenas no lado respetivo (cliente ou servidor):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -163,9 +164,9 @@ export default {
 }
 ```
 
-### A sintaxe de objeto
+### Sintaxe de Objeto
 
-Você pode também usar a sintaxe de objeto com a propriedade `mode` com o valor (`'client'` ou `'server'`) dento de `plugins`.
+Também podemos utilizar a sintaxe de objeto com a propriedade `mode` (`'client'` ou `'server'`) em `plugins`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -177,19 +178,19 @@ export default {
 }
 ```
 
-## Injetar dentro do `$root` e contexto
+## Injetar na `$root` e no Contexto
 
-Algumas vezes você deseja tornar as funções ou valores disponíveis ao longo da sua aplicação. Você pode injetar essas variáveis dentro das instâncias do Vue (lado do cliente), o contexto (lado do servidor) e até dentro da memória do Vuex. É uma convenção prefixar essas funções com um `$`.
+Por vezes, queremos disponibilizar funções ou valores em toda a nossa aplicação. Podemos injetar essas variáveis em instâncias de Vue (do lado do cliente), no contexto (do lado do servidor) e até no armazém de estado da Vuex. É uma convenção prefixar essas funções com um `$`.
 
-O Nuxt fornece a você uma maneira de fazer isso facilmente com um método `inject(key, value)`. O inject é dado como segundo parâmetro quando exportamos uma função. O `$` será pré-adicionado automaticamente a chave.
+A Nuxt fornece-nos um método `inject(key, value)` para fazer isto facilmente. A `inject` é dada como segundo parâmetro ao exportar uma função. O `$` será anexado automaticamente à chave.
 
 ::alert{type="info"}
-É importante saber que de todo [ciclo de vida da instância do Vue](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), apenas os gatilhos `beforeCreate` e `created` são chamados ambos, no lado do cliente e no lado do servidor. Todos os outros gatilhos são apenas chamado no lado do cliente.
+É importante saber que em qualquer [ciclo de vida duma instância de Vue](https://v2.vuejs.org/v2/guide/instance.html#Lifecycle-Diagram), apenas as funções gatilhos `beforeCreate` e `created` são chamadas tanto do lado do cliente quanto do lado do servidor. Todas as outras funções gatilhos são chamadas apenas do lado do cliente.
 ::
 
 ```js{}[plugins/hello.js]
 export default ({ app }, inject) => {
-  // Injete $hello(msg) dentro do Vue, contexto e memória.
+  // Injetar `$hello(msg)` na Vue, contexto e armazém de estado.
   inject('hello', msg => console.log(`Hello ${msg}!`))
 }
 ```
@@ -200,17 +201,17 @@ export default {
 }
 ```
 
-Agora o serviço `$hello` pode ser acessado a partir do `context` e `this` dentro das páginas, componentes, plugins, e ações da memória.
+Agora o serviço `$hello` pode ser acedido a partir de `context` e `this` em páginas, componentes, extensões, e ações do armazém de estado:
 
 ```js{}[example-component.vue]
 export default {
   mounted() {
     this.$hello('mounted')
-    // irá exibir no terminal 'Hello mounted!'
+    // imprimirá 'Hello mounted!'
   },
   asyncData({ app, $hello }) {
     $hello('asyncData')
-    // Se estiver usando Nuxt <= 2.12, use 👇
+    // Se usarmos Nuxt <= 2.12, usamos 👇
     app.$hello('asyncData')
   }
 }
@@ -231,14 +232,14 @@ export const actions = {
 ```
 
 ::alert{type="warning"}
-Não use o `Vue.use()`, `Vue.component()` e globalmente não conecte nada ao Vue **dentro** desta função, dedicada a injeção do Nuxt. Isso causará vazamento de memória no lado do servidor.
+Não é recomendado usar `Vue.use()`, `Vue.component()`, e não é recomendado fazer alterações no protótipo da Vue ou no objeto global da Vue **na** função exportada pela nossa extensão. (Isto causaria um vazamento de memória no lado do servidor). Consultar também [misturas globais](#misturas-globais).
 ::
 
-## A propriedade extendPlugins
+## A Propriedade `extendPlugins`
 
-Você talvez queira estender os plugins ou mudar as ordem dos plugins criada pelo Nuxt. Esta função aceita um array de objetos de [plugin](/docs/configuration-glossary/configuration-plugins) e deve retornar um array de objetos de plugin.
+Podemos querer estender as extensões ou alterar a ordem das extensões criada pela Nuxt. Esta função aceita um vetor de objetos de [extensão](/docs/configuration-glossary/configuration-plugins) e deve retornar um vetor de objetos de extensão.
 
-Exemplo de mudança da ordem de plugins:
+Exemplo de alteração da ordem das extensões:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -256,17 +257,17 @@ export default {
 }
 ```
 
-## Mixins global
+## Misturas Globais
 
-Mixins global pode ser facilmente adicionado com plugins do Nuxt mas pode causar problemas e vazamento de memória quando não manipulado corretamente. Sempre que você adicionar um mixin global a sua aplicação, você deve usar um bandeira para evitar registar ele várias vezes:
+As misturas globais podem ser facilmente adicionadas com as extensões de Nuxt, mas podem causar problemas e fugas de memória quando não são tratadas corretamente. Sempre que adicionarmos uma mistura global à nossa aplicação, devemos utilizar um sinalizador para evitar registá-la várias vezes:
 
 ```js{}[plugins/my-mixin-plugin.js]
 import Vue from "vue"
 
-// Certifique-se de pegar um nome único para a bandeira
-// assim ele não irá entrar em conflito com qualquer outro mixin.
+// Nos certificamos de que escolhemos um nome único para o sinalizador,
+// para não entrar em conflito com qualquer outra mistura.
 if (!Vue.__my_mixin__) {
   Vue.__my_mixin__ = true
-  Vue.mixin({ ... }) // Depois configure o seu mixin
+  Vue.mixin({ ... }) // Configurar a nossa mistura.
 }
 ```

--- a/content/pt/docs/4.directory-structure/11.static.md
+++ b/content/pt/docs/4.directory-structure/11.static.md
@@ -1,13 +1,14 @@
 ---
-title: O diretório static
-navigation.title: estático
-description: O diretório static é diretamente mapeado para a raiz do servidor () e contém ficheiros que raramente serão mudados. Todos ficheiros incluídos serão automaticamente servidos pelo Nuxt e estão acessíveis através da URL raiz do seu projeto.
+title: Diretório Estático
+navigation.title: static
+description: O diretório estático é mapeado diretamente para a raiz do servidor e contém ficheiros que provavelmente não serão alterados. Todos os ficheiros incluídos serão automaticamente servidos pela Nuxt e são acessíveis através do endereço de localização de recurso da raiz do projeto.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/13_static?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório static
 
-O diretório `static` é diretamente mapeado para a raiz do servidor () e contém ficheiros que raramente serão mudados. Todos ficheiros incluídos serão automaticamente servidos pelo Nuxt e estão acessíveis através da URL raiz do seu projeto.
+# Diretório Estático
+
+O diretório `static` é mapeado diretamente para a raiz do servidor e contém ficheiros que provavelmente não serão alterados. Todos os ficheiros incluídos serão automaticamente servidos pela Nuxt e são acessíveis através do endereço de localização de recurso da raiz do projeto.
 
 ---
 
@@ -15,28 +16,28 @@ O diretório `static` é diretamente mapeado para a raiz do servidor () e conté
 
 `/static/favicon.ico` estará disponível em `http://localhost:3000/favicon.ico`
 
-Esta opção é útil para ficheiros como `robots.txt`, `sitemap.xml` ou `CNAME` (o qual é importante para o processo de deploy no GitHub Pages).
+Esta opção é útil para ficheiros como `robots.txt`, `sitemap.xml` ou `CNAME` (que é importante para a implantação do GitHub Pages).
 
 ::alert{type="warning"}
-Este diretório não pode ser renomeado sem configuração extra.
+Este diretório não pode ser renomeado sem configuração adicional.
 ::
 
-## Os recursos estáticos
+## Recursos Estáticos
 
-Se você não quiser usar os recursos do Webpack do diretório `assets`, você pode adicionar imagens ao diretório static.
+Se não quisermos usar os recursos da Webpack do diretório `assets`, podemos adicionar as imagens ao diretório `static`.
 
-Dentro do seu código, você pode então referenciar esses ficheiros relativamente a raiz (`/`):
+No nosso código, podemos então referenciar estes ficheiros relativamente à raiz (`/`):
 
 ```html
-<!-- Imagem estática do diretório static -->
+<!-- Imagem estática do diretório `static` -->
 <img src="/my-image.png" />
 
-<!-- imagem empacotada pelo webpack do diretório assets -->
+<!-- Imagem empacotada pela webpack do diretório `assets` -->
 <img src="~/assets/my-image-2.png" />
 ```
 
 ::alert{type="info"}
-O Nuxt não muda este caminho, assim se você personalizar a sua `router.base` então você precisará fazer questão de adicionar ele manualmente aos seus caminhos. Por exemplo:
+A Nuxt não altera este caminho, então se personalizarmos a nossa `router.base` então precisaremos certificar-nos de adicioná-lo manualmente aos nossos caminhos. Por exemplo:
 
 ```html
 <img :src="`${yourPrefix}/my-image.png`" />
@@ -44,13 +45,13 @@ O Nuxt não muda este caminho, assim se você personalizar a sua `router.base` e
 ::
 
 
-## A configuração do diretório static
+## Configuração do Diretório Estático
 
-Se você precisar você pode configurar o comportamento do diretório `static/` dentro do ficheiro `nuxt.config.js`.
+Se necessário, podemos configurar o comportamento do diretório `static/` no ficheiro `nuxt.config.js`.
 
-### O prefixo do recurso estático
+### Prefixo de Recurso Estático
 
-Se você desdobrar o Nuxt para uma sub-pasta, exemplo `/blog/`, a base do router será adicionada ao caminho do recurso estático por padrão. Se você quiser desativar este comportamento, você pode definir `static.prefix` para false dentro do `nuxt.config.js`.
+Se implantarmos a Nuxt numa sub-pasta, por exemplo, `/blog/`, a base do roteador será adicionada ao caminho do recurso estático por predefinição. Se quisermos desativar este comportamento, podemos definir `static.prefix` como `false` no ficheiro `nuxt.config.js`:
 
 ```js
 export default {
@@ -60,6 +61,6 @@ export default {
 }
 ```
 
-Padrão: `/blog/my-image.png`
+Predefinido como: `/blog/my-image.png`
 
-Com o `static.prefix` desativado: `/my-image.png`
+Com a `static.prefix` desativada: `/my-image.png`

--- a/content/pt/docs/4.directory-structure/12.store.md
+++ b/content/pt/docs/4.directory-structure/12.store.md
@@ -1,48 +1,65 @@
 ---
-title: O diretório store
+title: Diretório do Armazém de Estado
 navigation.title: store
-description: O diretório store contém seus ficheiros de memória do Vuex. A memória do Vuex vem fora da caixa com o Nuxt mas está desativada por padrão. A criação de um ficheiro index.js dentro deste diretório ativa a memória.
+description: O diretório do armazém de estado contém os ficheiros do nosso armazém de estado de Vuex. O armazém de estado da Vuex é fornecido com a Nuxt de origem, mas está desativada por predefinição. A criação de um ficheiro de índice neste diretório ativa o armazém de estado.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/14_store?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório store
 
-O diretório `store` contém seus ficheiros de memória do Vuex. A memória do Vuex vem fora da caixa com o Nuxt mas está desativada por padrão. A criação de um ficheiro index.js dentro deste diretório ativa a memória.
+# Diretório do Armazém de Estado
+
+O diretório `store` contém os ficheiros do nosso armazém de estado de Vuex. O armazém de estado da Vuex é fornecido com a Nuxt de origem, mas está desativada por predefinição. A criação de um ficheiro `index.js` neste diretório ativa o armazém de estado.
 
 ---
 
 ::alert{type="warning"}
-Este diretório não pode ser renomeado sem configuração extra.
+Este diretório não pode ser renomeado sem configuração adicional.
 ::
 
-Usar uma memória para gerir o estado é importante para toda grande aplicação. Isto é o porquê do Nuxt implementar o Vuex dentro do seu núcleo.
+A utilização de um armazém de estado para gerir o estado é importante para todas as grandes aplicações. É por isto que a Nuxt implementa a Vuex no seu núcleo.
 
-## Ativar a memória
+## Ativar o Armazém de Estado
 
 O Nuxt irá procurar pelo diretório `store`. Se ele conter um ficheiro, que não seja um ficheiro oculto ou um ficheiro `README.md`, então a memória será ativada. Isto significa que o Nuxt irá:
+A Nuxt procurará pelo diretório `store`. Se conter um ficheiro, que não é um ficheiro oculto ou um ficheiro `README.md`, então o armazém de estado será ativado. Isto significa que a Nuxt:
 
-1. Importar o Vuex
-2. Adicionar a opção `store` à instância raíz do Vue.
+1. Importará a Vuex
+2. Adicionará a opção `store` à instância raiz do Vue.
 
-## Os módulos
+## Módulos
 
-Todo ficheiro `.js` dentro do diretório `store` é transformado em um [módulo com nome reservado](http://vuex.vuejs.org/en/modules.html)(com o `index` sendo a raiz do módulo). O seu valor de `state` sempre será uma `function` para evitar estado *partilhado* indesejado no lado do servidor.
+Cada ficheiro `.js` no diretório `store` é transformado num [módulo nominal](http://vuex.vuejs.org/en/modules.html) (sendo `index` o módulo raiz). O nosso valor `state` deve ser sempre uma `function` para evitar estado *partilhado* indesejado no lado do servidor.
 
-Para começar, exporte o estado (state) como uma função, e as mutações (mutations) e ações (actions) como objetos.
+Para começarmos, exportamos o estado (`state`), como uma função (`function`) e os recuperadores (`getters`), mutações (`mutations`) e ações (`actions`) como objetos (`object`):
 
 ```js{}[store/index.js]
 export const state = () => ({
   counter: 0
 })
 
+export const getters = {
+  getCounter(state) {
+    return state.counter
+  }
+}
+
 export const mutations = {
   increment(state) {
     state.counter++
   }
 }
+
+export const actions = {
+  async fetchCounter({ state }) {
+    // requisitar
+    const res = { data: 10 };
+    state.counter = res.data;
+    return res.data;
+  }
+}
 ```
 
-Depois, você pode ter um ficheiro `store/todos.js`:
+Então, podemos ter um ficheiro `store/todos.js`:
 
 ```js{}[store/todos.js]
 export const state = () => ({
@@ -65,7 +82,7 @@ export const mutations = {
 }
 ```
 
-A memória será criada tal e qual:
+O armazém de estado será criado como tal:
 
 ```js
 new Vuex.Store({
@@ -102,7 +119,7 @@ new Vuex.Store({
 })
 ```
 
-E dentro do seu `pages/todos.vue`, ao usar o módulo `todos`:
+E no nosso `pages/todos.vue`, ao usar o módulo `todos`:
 
 ```js{}[pages/todos.vue]
 <template>
@@ -143,9 +160,9 @@ export default {
 </style>
 ```
 
-O método do módulo também funciona para definições de alto-nível sem a implementação de um sub-diretório dentro do diretório store.
+O método do módulo também funciona para definições de alto nível sem implementar um sub-diretório no diretório do armazém de estado.
 
-Exemplo para estado (state): você cria um ficheiro `store/state.js` e adiciona o seguinte.
+Exemplo para o estado (`state`): criamos um ficheiro `store/state.js` e adicionamos o seguinte:
 
 ```js
 export default () => ({
@@ -153,9 +170,9 @@ export default () => ({
 })
 ```
 
-E os recuperadores (getters) podem estar no ficheiro `store/getter.js`:
+E os recuperadores (`getters`) correspondentes podem estar no ficheiro `store/getters.js`:
 
-```js{}[store/getter.js]
+```js{}[store/getters.js]
 export default {
   getCounter(state) {
     return state.counter
@@ -163,7 +180,7 @@ export default {
 }
 ```
 
-E as mutações (mutations) correspondentes podem estar no ficheiro `store/mutations.js`
+E as mutações (`mutations`) correspondentes podem estar no ficheiro `store/mutations.js`:
 
 ```js{}[store/mutations.js]
 export default {
@@ -173,22 +190,22 @@ export default {
 }
 ```
 
-E as ações (actions) correspondentes podem estar no ficheiro `store/actions.js`:
+E as ações (`actions`) correspondentes podem estar no ficheiro `store/actions.js`:
 
 ```js{}[store/actions.js]
 export default {
   async fetchCounter({ state }) {
-    // fazer requisição
-    const response = { data: 10 };
-    state.counter = response.data;
-    return response.data;
+    // requisitar
+    const res = { data: 10 };
+    state.counter = res.data;
+    return res.data;
   }
 }
 ```
 
 ### Exemplo de estrutura de pasta
 
-Uma configuração complexa da estrutura de ficheiro/pasta memória pode parecer com isto:
+Uma estrutura complexa de ficheiros ou pastas de configuração do armazém de estado pode ter o seguinte aspeto:
 
 ```
  store/
@@ -207,9 +224,9 @@ Uma configuração complexa da estrutura de ficheiro/pasta memória pode parecer
 --------| state.js
 ```
 
-## Os plugins na memória
+## Extensões no Armazém de Estado
 
-Você pode adicionar plugins adicionais à memória ao por eles dentro do ficheiro `store/index.js`:
+Podemos adicionar extensões adicionais ao armazém de estado, colocando-os no ficheiro `store/index.js`:
 
 ```js{}[store/index.js]
 import myPlugin from 'myPlugin'
@@ -227,13 +244,13 @@ export const mutations = {
 }
 ```
 
-Mais informações sobre os plugins na: [documentação do Vuex](https://vuex.vuejs.org/en/plugins.html).
+Mais informações sobre as extensões: [documentação da Vuex](https://vuex.vuejs.org/en/plugins.html).
 
-## A ação nuxtServerInit
+## A Ação `nuxtServerInit`
 
-Se a ação `nuxtServerInit` estiver definida dentro da memória (store) e o modo estiver em `universal`, o Nuxt irá chamar ele com o contexto (apenas a partir do lado do servidor). É útil quando nós temos algum dado no servidor que nós queremos dar diretamente para o lado do cliente.
+Se a ação `nuxtServerInit` estiver definida no armazém de estado e o modo for `universal`, a Nuxt a chamará com o contexto (somente do lado do servidor). É útil quando temos alguns dados no servidor que queremos fornecer diretamente ao lado do cliente.
 
-Por exemplo, vamos dizer que temos sessões no lado do servidor e podemos acessar o usuário conectado através do `req.session.user`. Para adicionar o usuário autenticado a nossa memória (store), nós atualizamos o nosso `store/index.js` para o seguinte:
+Por exemplo, digamos que temos sessões no lado do servidor e podemos aceder ao utilizador conectado através da `req.session.user`. Para adicionar o utilizador autenticado ao nosso armazém de estado, atualizamos o nosso `store/index.js` para o seguinte:
 
 ```js{}[store/index.js]
 actions: {
@@ -246,15 +263,15 @@ actions: {
 ```
 
 ::alert{type="warning"}
-Somente o módulo primário (dentro do `store/index.js`) será receber esta ação. Você precisará encadear as ações do módulo a partir de lá.
+Só o módulo principal (em `store/index.js`) receberá esta ação. Temos de encadear as ações do nosso módulo a partir daí.
 ::
 
-O [contexto](/docs/concepts/context-helpers) é dado ao `nuxtServerInit` como o segundo argumento dentro do método `asyncData`.
+O [contexto](/docs/concepts/context-helpers)  é fornecido a `nuxtServerInit` como o segundo argumento no método `asyncData`.
 
-Se o `nuxt generate` for executado, o `nuxtServerInit` será executado para cada rota dinâmica gerada.
+Se o `nuxt generate` for executado, a `nuxtServerInit` será executada para cada rota dinâmica gerada.
 
 ::alert{type="info"}
-Ações do `nuxtServerInit` assíncronas devem retornar uma promessa (Promise) ou usar o async/await para permitir o servidor do nuxt esperar neles. 
+As ações assíncronas de `nuxtServerInit` devem retornar uma promessa (`Promise`) ou utilizar `async` e `await` para permitir o servidor da Nuxt esperar por estas.
 ::
 
 ```js{}[store/index.js]
@@ -265,9 +282,9 @@ actions: {
 }
 ```
 
-## O modo estrito do Vuex
+## Modo Estrito da Vuex
 
-O modo estrito está ativado por padrão no modo de desenvolvimento e desativado no modo de produção. Para desativar o modo estrito em desenvolvimento, siga o exemplo abaixo dentro do `store/index.js`:
+O modo estrito é ativado por predefinição no modo de desenvolvimento e desativado no modo de produção. Para desativar o modo estrito no desenvolvimento, sigamos o exemplo abaixo em `store/index.js`:
 
 ```js
 export const strict = false

--- a/content/pt/docs/4.directory-structure/13.nuxt-config.md
+++ b/content/pt/docs/4.directory-structure/13.nuxt-config.md
@@ -1,21 +1,22 @@
 ---
-title: O ficheiro de configuração do Nuxt
+title: Ficheiro de Configuração da Nuxt
 navigation.title: nuxt.config
-description: Por padrão, o Nuxt está configurado para cobrir a maior parte dos casos de uso. Esta configuração pode ser sobrescrita com o ficheiro nuxt.config.js.
+description: Por predefinição, a Nuxt está configurada para cobrir a maioria dos casos de uso. Esta configuração predefinida pode ser sobrescrita com o ficheiro de configuração da Nuxt.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/15_nuxt-config?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O ficheiro de configuração do Nuxt
 
-Por padrão, o Nuxt está configurado para cobrir a maior parte dos casos de uso. Esta configuração pode ser sobrescrita com o ficheiro nuxt.config.js.
+# Ficheiro de Configuração da Nuxt
+
+Por predefinição, a Nuxt está configurada para cobrir a maioria dos casos de uso. Esta configuração predefinida pode ser sobrescrita com o ficheiro de `nuxt.config.js`.
 
 ---
 
-## nuxt.config.js
+## `nuxt.config.js`
 
-### A propriedade alias
+### `alias`
 
-Esta opção permite você definir apelidos que estarão disponíveis dentro do seu JavaScript e CSS.
+Esta opção permite-nos definir pseudónimos que estarão disponíveis no nosso código de JavaScript e CSS:
 
 ```js{}[nuxt.config.js]
 import { resolve } from 'path'
@@ -28,19 +29,19 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade alias](/docs/configuration-glossary/configuration-alias)
+Saber mais sobre a [propriedade `alias`](/docs/configuration-glossary/configuration-alias).
 ::
 
-### A propriedade build
+### `build`
 
-
-Esta opção permite você configurar várias definições para o passo `build`, incluindo `loaders`, `filenames`, a configuração do `webpack` e `transpilation`.
+Esta opção permite-nos configurar várias definições para o passo de `build`, incluindo `loaders`, `filenames`, a configuração da `webpack` e `transpilation`:
 
 ```js{}[nuxt.config.js]
 export default {
   build: {
     /*
-     ** Você pode estender a configuração do webpack aqui
+     ** Podemos estender a configuração da
+     ** webpack neste contexto.
      */
     extend(config, ctx) {}
   }
@@ -48,12 +49,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade build](/docs/configuration-glossary/configuration-build)
+Saber mais sobre a [propriedade `build`](/docs/configuration-glossary/configuration-build).
 ::
 
-### A propriedade css
+### `css`
 
-Esta opção permite você definir os ficheiros CSS, módulos e bibliotecas que você quiser incluir globalmente (em todas páginas).
+Esta opção permite-nos definir os ficheiros de folha de estilo em cascata, módulos e bibliotecas que queremos incluir globalmente (em todas as páginas):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -61,7 +62,7 @@ export default {
 }
 ```
 
-Você pode omitir a extensão para CSS, SCSS, PostCSS, LESS, Stylus, ... ficheiros listados dentro o array css dentro do seu ficheiro de configuração do nuxt.
+Podemos omitir a extensão do ficheiro para todos os ficheiros de folha de estilo, tais como `.css`, `sass`,`.scss`, `.postcss`, `.less`, `.stylus`, `.styl`, e outros, listados no vetor `css` no nosso ficheiro de configuração da Nuxt:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -69,15 +70,15 @@ export default {
 }
 ```
 
-Ao omitir a extensão, se você tiver um ficheiro css e decidir mudar para usar sass por exemplo, você não terá de atualizar o seu `nuxt.config.js` assim ele usará a nova extensão uma vez que nome do ficheiro permanece o mesmo.
+Ao omitir a extensão, se tivermos um ficheiro de folha de estilo em cascata com a extensão `.css` e decidirmos mudar para usar `.sass` ou `.scss`, por exemplo, não teremos de atualizar o nosso `nuxt.config`, porque este usará a nova extensão, uma vez que o nome do ficheiro permanece o mesmo.
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade css](/docs/configuration-glossary/configuration-css)
+Saber mais sobre a [propriedade `css`](/docs/configuration-glossary/configuration-css).
 ::
 
-### A propriedade dev
+### `dev`
 
-Esta opção permite você definir o modo de `development` (desenvolvimento) ou `production` (produção) do Nuxt (importante para quando você usar o Nuxt programaticamente).
+Esta opção permite-nos definir o modo `development` ou `production` da Nuxt (importante quando usamos a Nuxt programaticamente):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -86,12 +87,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade dev](/docs/configuration-glossary/configuration-dev)
+Saber mais sobre a [propriedade `dev`](/docs/configuration-glossary/configuration-dev).
 ::
 
-### A propriedade env
+### `env`
 
-Esta opção permite você definir variáveis de ambientes que são requeridas no momento da construção (ao invés do momento de execução) tais como `NODE_ENV=staging` ou `VERSION=1.2.3`. Contudo, para as variáveis do tempo de execução o `runtimeConfig` é requerido.
+Esta opção permite-nos definir variáveis de ambientes necessárias em tempo de construção (ao invés de definirmos em tempo de execução) como `NODE_ENV=staging` ou `VERSION=1.2.3`. No entanto, para variáveis de ambiente de tempo de execução a `runtimeConfig` é obrigatória:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -101,20 +102,20 @@ export default {
 }
 ```
 
-### A propriedade runtimeConfig
+### `runtimeConfig`
 
-A configuração do tempo de execução tem suporte embutido ao [dotenv](https://github.com/motdotla/dotenv) para uma segurança melhor e rápido desenvolvimento. A configuração do tempo de execução é adicionada ao payload do Nuxt assim não há necessidade de reconstruir no sentido de atualizar a configuração do tempo de execução quando estiver trabalhando em desenvolvimento ou com a renderização no lado do servidor ou com apenas aplicações no lado do cliente. (Para sites estáticos você continuará a precisar regerar o seu site para ver as mudanças).
+A configuração de tempo de execução tem suporte embutido de [`dotenv`](https://github.com/motdotla/dotenv) para melhor segurança e desenvolvimento mais rápido. A configuração de tempo de execução é adicionada à carga útil da Nuxt, pelo que não é necessário reconstruir para atualizar a configuração de tempo de execução quando se trabalha em desenvolvimento ou com aplicações interpretadas do lado do servidor ou interpretadas apenas do lado do cliente. (No caso dos sítios estáticos, continuaremos a ter de regerar o nosso sítio para ver as alterações).
 
-#### Suporte ao ponto env
+#### Suporte ao `.env`
 
-Se você tiver um ficheiro `.env` dentro do diretório raiz do seu projeto, ele será automaticamente carregado dentro do `process.env` e acessível dentro do seu `nuxt.config`/`serverMiddleware` e quaisquer outros ficheiros que eles importar.
+Se tivermos um ficheiro `.env` no diretório raiz do nosso projeto, este será carregado automaticamente em `process.env` e acessível dentro do nosso `nuxt.config` ou do `serverMiddleware` e quaisquer outros ficheiros que estes importem.
 
-Você pode personalizar o caminho ao usar `--dotenv <file>` ou desativar completamente com `--dotenv false`. Por exemplo, você pode especificar um ficheiro diferente `.env` em ambientes de produção, montagem ou desenvolvimento.
+Podemos personalizar o caminho utilizando `--dotenv <file>` ou desativar completamente com `--dotenv false`. Por exemplo, podemos especificar um ficheiro `.env` diferente nos ambientes de produção, preparação (ou testes), ou desenvolvimento.
 
-#### A propriedade publicRuntimeConfig
+#### `publicRuntimeConfig`
 
-- deve carregar todas variáveis de ambientes que são publicas assim esses serão expostas no frontend. Isto pode incluir uma referência para sua URL pública por exemplo.
-- está disponível ao usar `$config` dentro de ambos servidor e cliente.
+- deve conter todas as variáveis de ambiente públicas, uma vez que estas serão expostas no frontend. Isto pode incluir uma referência ao nosso endereço público de localização de recurso, por exemplo.
+- está disponível ao usar `$config` tanto no servidor como no cliente.
 
 ```js{}[nuxt.config.js]
 export default {
@@ -124,10 +125,10 @@ export default {
 }
 ```
 
-#### A propriedade privateRuntimeConfig
+#### `privateRuntimeConfig`
 
-- deve carregar todas variáveis de ambiente que são privadas e que não devem ser expostas no frontend. Isto pode incluir uma referência para os seus símbolos secretos da API por exemplo.
-- apenas está disponível no servidor ao usar o mesmo `$config` (ele sobrescreve o publicRuntimeConfig)
+- deve conter todas as variáveis de ambiente privadas e que não devem ser expostas no frontend. Isto pode incluir uma referências aos símbolos secretos da nossa interface de programação de aplicação, por exemplo.
+- só está disponível no servidor com uso da mesma `$config` (sobrepõe a `publicRuntimeConfig`).
 
 ```js{}[nuxt.config.js]
 export default {
@@ -137,9 +138,9 @@ export default {
 }
 ```
 
-#### **Usando seus valores de configuração:**
+#### **Usar os Nossos Valores de Configuração:**
 
-Você pode então acessar esses valores em qualquer lugar ao usar o contexto dentro de suas páginas, memória, componentes e plugins ao usar `this.$config` ou `context.$config`.
+Podemos então acessar estes valores em qualquer lugar ao usar o contexto nas nossas páginas, no armazém de estado, componentes e extensões ao usar `this.$config` ou `context.$config`:
 
 ```html{}[pages/index.vue]
 <script>
@@ -150,7 +151,7 @@ Você pode então acessar esses valores em qualquer lugar ao usar o contexto den
 </script>
 ```
 
-Dentro dos seus modelos você pode acessar suas configurações de tempo de execução diretamente usando `$config.*`
+Dentro dos nossos modelos de marcação de hipertexto, podemos acessar as nossas configurações de tempo de execução diretamente ao usar `$config.*`:
 
 ```html{}[pages/index.vue]
 <template>
@@ -159,39 +160,43 @@ Dentro dos seus modelos você pode acessar suas configurações de tempo de exec
 ```
 
 ::alert{type="warning"}
-A sua configuração privada pode ser exposta se você usar `$config` fora de um contexto de apenas servidor (por exemplo, se você usar `$config` dentro do `fetch`, `asyncData` ou diretamente dentro do seu modelo).
+A nossa configuração privada pode ser exposta se utilizarmos `$config` fora de um contexto exclusivo de servidor (por exemplo, se utilizarmos `$config` em `fetch`, `asyncData` ou diretamente dentro do nosso modelo de marcação de hipertexto).
 ::
 
 ::alert{type="next"}
-Para saber mais consulte por [runtimeConfig](/docs/configuration-glossary/configuration-runtime-config)
+Saber mais sobre a [`runtimeConfig`](/docs/configuration-glossary/configuration-runtime-config).
 ::
 
 ::alert{type="next"}
-Consulte a publicação do nosso blogue em [Migrando de @nuxtjs/dotenv para configuração do tempo de execução](/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config)
+Consultar a publicação do nosso blogue sobre [Migrar da `@nuxtjs/dotenv` para `runtimeConfig`](/tutorials/moving-from-nuxtjs-dotenv-to-runtime-config).
 ::
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade env](/docs/configuration-glossary/configuration-env)
+Saber mais sobre a [propriedade `env`](/docs/configuration-glossary/configuration-env).
 ::
 
-### A propriedade generate
+### `generate`
 
-Esta opção permite você definir valores de parâmetros para cada rota dinâmica dentro da sua aplicação que será transformada em ficheiros HTML pelo Nuxt.
+Esta opção permite-nos definir valores de parâmetros para cada rota dinâmica da nossa aplicação que será transformada em ficheiros `.html` pela Nuxt:
 
 ```js{}[nuxt.config.js]
 export default {
   generate: {
-    dir: 'gh_pages', // gh_pages/ ao invés de dist/
-    subFolders: false // Ficheiros HTML são gerados de acordo com caminho da rota
+    // `gh_pages/` em vez de `dist/`
+    dir: 'gh_pages',
+    // Os ficheiros `.html` são gerados de acordo o caminho da rota.
+    subFolders: false
   }
 }
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade generate](/docs/configuration-glossary/configuration-generate)
+Saber mais sobre a [propriedade `generate`](/docs/configuration-glossary/configuration-generate).
 ::
 
-### head
+### `head`
+
+Esta opção permite-nos definir todos os meta-marcadores predefinidos para a nossa aplicação:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -205,15 +210,13 @@ export default {
 }
 ```
 
-Esta opção permite você definir todas as metas tags padrão para sua aplicação.
-
 ::alert{type="next"}
-Para saber mais consulte pela [integração do head](/docs/configuration-glossary/configuration-head)
+Saber mais sobre a [propriedade `head`](/docs/configuration-glossary/configuration-head).
 ::
 
-### A propriedade loading
+### `loading`
 
-Esta opção permite você personalizar o componente de carregamento que o Nuxt usa por padrão.
+Esta opção permite-nos personalizar o componente de carregamento que a Nuxt utiliza por predefinição:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -224,12 +227,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [integração do loading](/docs/configuration-glossary/configuration-loading)
+Saber mais sobre a [integração do carregamento](/docs/configuration-glossary/configuration-loading).
 ::
 
-### A propriedade modules
+### `modules`
 
-Com esta opção você pode adicionar módulos de Nuxt ao seu projeto.
+Com esta opção, podemos adicionar módulos de Nuxt ao nosso projeto:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -238,12 +241,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade modules](/docs/configuration-glossary/configuration-modules)
+Saber mais sobre a [propriedade `modules`](/docs/configuration-glossary/configuration-modules).
 ::
 
-### A propriedade modulesDir
+### `modulesDir`
 
-A propriedade modelesDir é usada para definir os diretórios dos módulos para resolução do caminho. Por exemplo: resolveLoading, nodeExternals e postcss do webpack. O caminho de configuração é relativo ao `options.rootDir` (padrão: process.cwd()).
+A propriedade `modelsDir` é usada para definir os diretórios dos módulos para a resolução de caminhos. Por exemplo: `resolveLoading`, `nodeExternals` e `postcss` da Webpack. O caminho de configuração é relativo a `options.rootDir` (predefinida como: `process.cwd()`):
 
 ```js{}[nuxt.config.js]
 export default {
@@ -251,15 +254,15 @@ export default {
 }
 ```
 
-Configurar este campo pode ser necessário se seu projeto está organizado como um espaço de trabalho de mono-repositório com Yarn.
+A definição deste campo pode ser necessária se o nosso projeto estiver organizado como um mono-repositório do tipo de espaço de trabalho da Yarn.
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade modulesDir](/docs/configuration-glossary/configuration-modulesdir)
+Saber mais sobre a [propriedade `moduleDir`](/docs/configuration-glossary/configuration-modulesdir).
 ::
 
-### A propriedade plugins
+### `plugins`
 
-Esta opção permite você definir plugins escritos em JavaScript que devem ser executados antes da inicialização da raiz da aplicação Vue.js.
+Esta opção permite-nos definir extensões de JavaScript que devem ser executadas antes de instanciar a aplicação de Vue.js raiz:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -268,12 +271,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade plugins](/docs/configuration-glossary/configuration-plugins)
+Saber mais sobre a [propriedade `plugins`](/docs/configuration-glossary/configuration-plugins).
 ::
 
-### A propriedade router
+### `router`
 
-Com a opção `router` você pode sobrescrever a configuração padrão do Nuxt do Vue Router.
+Com a opção `router`, podemos sobrescrever a configuração da Vue Router predefinida pela Nuxt:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -284,12 +287,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade router](/docs/configuration-glossary/configuration-router)
+Saber mais sobre a [propriedade `router`](/docs/configuration-glossary/configuration-router).
 ::
 
-### A propriedade server
+### `server`
 
-Está opção permite você configurar as variáveis de conexão para a instância da sua aplicação Nuxt.
+Esta opção permite-nos configurar as variáveis de conexão para a instância do servidor da nossa aplicação de Nuxt:
 
 ```js{}[nuxt.config.js]
 import path from 'path'
@@ -306,12 +309,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade server](/docs/configuration-glossary/configuration-server)
+Saber mais sobre a [propriedade `server`](/docs/configuration-glossary/configuration-server).
 ::
 
-### A propriedade srcDir
+### `srcDir`
 
-Esta opção permite você definir o diretório fonte da sua aplicação Nuxt.
+Esta opção permite-nos definir o diretório de origem da nossa aplicação de Nuxt:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -319,7 +322,7 @@ export default {
 }
 ```
 
-Exemplo da estrutura do projeto com a sua aplicação Nuxt dentro do diretório `client`.
+Exemplo de estrutura de projeto com a nossa aplicação de Nuxt no diretório `client`:
 
 ```bash
 **-| app/
@@ -337,25 +340,26 @@ Exemplo da estrutura do projeto com a sua aplicação Nuxt dentro do diretório 
 ------| store/**
 ```
 
-### A propriedade dir
+### `dir`
 
-Esta opção permite você definir nomes personalizados dos seus diretórios do Nuxt.
+Esta opção permite-nos definir nomes personalizados para os nossos diretórios da Nuxt:
 
 ```js{}[nuxt.config.js]
 export default {
   dir: {
-    pages: 'views' // O Nuxt buscará pela pasta views/ ao invés da pasta pages/
+    // A Nuxt procurará a pasta `views` em vez da pasta `pages`.
+    pages: 'views'
   }
 }
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade dir](/docs/configuration-glossary/configuration-dir)
+Saber mais sobre a [propriedade `dir`](/docs/configuration-glossary/configuration-dir).
 ::
 
-### A propriedade pageTransition
+### `pageTransition`
 
-Esta opção permite você definir as propriedades de transições da página.
+Esta opção permite-nos definir as propriedades predefinidas das transições de página:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -364,23 +368,23 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais consulte pela [propriedade transition](/docs/configuration-glossary/configuration-transition)
+Saber mais sobre a [propriedade `transition`](/docs/configuration-glossary/configuration-transition).
 ::
 
-## Outros ficheiros de configuração
+## Outros Ficheiros de Configuração
 
-Além do `nuxt.config.js` podem haver outros ficheiros de configuração dentro da raíz do seu projeto, tais como o [.eslintrc](https://eslint.org/), [prettier.config.json](https://prettier.io/) ou [.gitignore](https://git-scm.com/docs/gitignore). Estes são usados para configurar outras ferramentas tais como o seu linter, formatador de código ou o seu repositório do git e independente do `nuxt.config.js`.
+Para além do `nuxt.config.js` podem existir outros ficheiros de configuração na raiz do nosso projeto, tais como [`.eslintrc`](https://eslint.org/), [`prettier.config.json`](https://prettier.io/) ou [`.gitignore`](https://git-scm.com/docs/gitignore). Estes são utilizados para configurar outras ferramentas como o nosso analisador de qualidade de código (conhecido como `linter`) ou o nosso repositório de `git` e separados do `nuxt.config.js`.
 
-### O ficheiro .gitignore
+### `.gitignore`
 
-Dentro do seu ficheiro .gitignore você precisará adicionar os seguintes diretórios, assim eles serão ignorados e não adicionados ao controlo de versão. `node_modules` o qual é onde todos os seus módulos instalados estão. A pasta `.nuxt` a que é criada quando estiver executando os comandos `dev` ou `build`. A pasta `dist` é a pasta que é criada quando estiver executando o comando generate.
+No nosso ficheiro `.gitignore`, teremos de adicionar o seguinte para serem ignorados e não serem adicionados ao controlo de versões. `node_modules` que é onde estão todos o nossos módulos instalados. A pasta `nuxt` que é a que é criada quando se executa os comandos de desenvolvimento (`dev`) ou construção (`build`). A pasta `dist` é a pasta que é criada ao executar o comando geração (`generate`):
 
 ```markdown{}[.gitignore]
 node_modules .nuxt dist
 ```
 
-### O que segue
+### O Que Se Segue?
 
 ::alert{type="next"}
-Para saber mais consulte o [glossário da configuração](/docs/configuration-glossary/configuration-build)
+Consultar o [glossário de configuração](/docs/configuration-glossary/configuration-build).
 ::

--- a/content/pt/docs/4.directory-structure/2.assets.md
+++ b/content/pt/docs/4.directory-structure/2.assets.md
@@ -1,20 +1,22 @@
 ---
-title: O diretório assets
+title: Diretório de Recursos
 navigation.title: assets
-description: O diretório assets contém assets não compilados tais como ficheiros Stylus ou Sass, imagens, ou fontes.
+description: O diretório de recursos contém os nossos recursos ou ativos não compilados, como ficheiros de pré-processadores de folhas de estilos em cascata, imagens ou tipos de letra.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/02_assets?fontsize=14&hidenavigation=1&theme=dark
 videoScript:
   - assets-video.md
 ---
-# O diretório assets
 
-O diretório `assets` contém recursos não compilados tais como ficheiros Stylus ou Sass, imagens, ou fontes.
+# Diretório de Recursos
+
+O diretório `assets` contém recursos ou ativos não compilados, como ficheiros `.styl`, `.stylus` ou `.sass`, `.scss`, imagens, ou tipos de letras (também conhecidos como fontes).
+
 ---
 
-## As imagens
+## Imagens
 
-Dentro dos seus modelos `vue`, se você precisar ligar ao seu diretório `assets`, use `~/assets/your_image.png` com uma barra antes do assets.
+Dentro dos nossos modelos de marcação `.vue`, se precisarmos vincular ao nosso diretório `assets`, usamos `~/assets/your_image.png` com uma barra antes de `assets`:
 
 ```html
 <template>
@@ -22,42 +24,43 @@ Dentro dos seus modelos `vue`, se você precisar ligar ao seu diretório `assets
 </template>
 ```
 
-Dentro dos seus ficheiros `css`, se você precisar referenciar o seu diretório `assets`, use `~assets/your_image.png` (sem uma barra).
+Dentro dos nossos ficheiros `.css`m se precisarmos de referenciar o nosso diretório `assets`, utilizamos `~assets/your_image.png` (sem barra):
 
 ```css
 background: url('~assets/banner.svg');
 ```
 
-Quando estiveres trabalhando com imagens dinâmicas você precisará usar a função `require()`
+Quando trabalhamos com imagens dinâmicas, precisamos de utilizar a função `require()`:
 
 ```html
 <img :src="require(`~/assets/img/${image}.jpg`)" />
 ```
 
 ::alert{type="next"}
-Aprenda mais sobre [os recursos do webpack](/docs/directory-structure/assets#os-recursos-do-webpack)
+Saber mais sobre os [recursos ou ativos da Webpack](/docs/directory-structure/assets#webpack-assets).
 ::
 
-## Os estilos
+## Estilos
 
-O Nuxt permite você definir ficheiros/módulos/bibliotecas CSS que você quiser definir globalmente (incluído dentro de cada página). Dentro do ficheiro `nuxt.config.js` você pode facilmente adicionar seus estilos usando a propriedade CSS.
+A Nuxt permite-nos definir os ficheiros `.css`, módulos, e bibliotecas que queremos definir globalmente (incluídos em todas as páginas). No `nuxt.config.js`, podemos adicionar facilmente os nossos estilos utilizando a propriedade `css`:
 
 ```js{}[nuxt.config.js]
 export default {
   css: [
-    // Carrega um módulo do Node.js diretamente (aqui está um ficheiro Sass)
+    // Carregar um módulo de Node.js diretamente
+    // (neste caso, é um ficheiro `.scss` ou `.sass`).
     'bulma',
-    // Ficheiro CSS dentro do projeto
+    // Ficheiro `.css` no projeto
     '~/assets/css/main.css',
-    // Ficheiro SCSS dentro do projeto
+    // Ficheiro `.scss` no projeto
     '~/assets/css/main.scss'
   ]
 }
 ```
 
-### O Sass
+### Sass
 
-No caso de você quiser usar `sass` certifique-se que você tem os pacotes `sass` e `sass-loader` instalado.
+Caso queiramos utilizar a `sass` precisamos ter certeza de que instalamos os pacotes `sass` e `sass-loader`:
 
 ::code-group
 ```bash [Yarn]
@@ -68,11 +71,11 @@ npm install --save-dev sass sass-loader@10
 ```
 ::
 
-O Nuxt irá automaticamente adivinhar o tipo de ficheiro pela sua extensão e usar o carregador do pré-processador adequado para o webpack. Você continuará a precisar instalar o carregador exigido se você precisar usar eles.
+A Nuxt deteta automaticamente o tipo de ficheiro pela sua extensão de ficheiro (`.sass` ou `.scss`) e utiliza o carregador do pré-processador correto para a Webpack. Continuaremos a ter de instalar o carregador necessário se precisarmos de os utilizar:
 
-## As fontes
+## Tipos de Letra
 
-Você pode usar fontes locais ao adicionar elas à sua pasta `assets`. Uma vez que eles têm sido adicionados você pode então acessar eles através do seu CSS usando o `@font-face`.
+Podemos utilizar tipos de letra (mais conhecidos como fontes) locais adicionando-os à nossa pasta de recursos (`assets/`). Uma vez adicionados, podemos acessá-los através do nosso `.css` utilizando a `@font-face`:
 
 ```
 -| assets
@@ -100,22 +103,22 @@ Você pode usar fontes locais ao adicionar elas à sua pasta `assets`. Uma vez q
 ```
 
 ::alert{type="info"}
-Os ficheiros CSS não são automaticamente carregados. Adicione eles usando a [propriedade de configuração do CSS](https://v2.nuxt.com/docs/configuration-glossary/configuration-css/).
+Os ficheiros `.css` não são carregados automaticamente. Precisamos adicioná-los usando a [propriedade de configuração `css`](/docs/configuration-glossary/configuration-css/).
 ::
 
 ::alert{type="next"}
-Para adicionar fontes externas taís como as do Google Fonts consulte o [capítulo Meta Tags e SEO](/docs/features/meta-tags-seo#recursos-externos)
+Para adicionar os tipos de letra externas, como as do Google Fonts, consular o capítulo de [meta-marcadores e a otimização dos motores de pesquisa](/docs/features/meta-tags-seo#recursos-externos).
 ::
 
-## Os recursos do webpack
+## Recursos da Webpack
 
-Por padrão, o Nuxt usa o `vue-loader` do webpack, `file-loader`, e o `url-loader` para servir seus assets. Você também pode usar o diretório `static` para os recursos que não devem ser processados pelo webpack
+Por predefinição, a Nuxt usa a `vue-loader`, `file-loader`, e a `url-loader` da Webpack para servir os nossos recursos (também conhecidos como ativos). Também podemos usar o diretório estático (`static/`) para recursos (`assets/`) que não devem ser executados pela Webpack:
 
 ## Webpack
 
-O [vue-loader](http://vue-loader.vuejs.org/) processa automaticamente seu estilo e ficheiros de modelos com o `css-loader` e o compilador de modelos do Vue. Neste processo de compilação, todas URLs do recurso tais como `<img src="...">`, `background: url(...)`, e os `@import` do CSS são resolvidos como módulo de dependências.
+A [`vue-loader`](http://vue-loader.vuejs.org/) processa os nossos ficheiros de estilo e modelos de marcação automaticamente com a `css-loader` e a compilara de modelos de marcação de hipertexto com extensão `.vue`. Neste processo de compilação, todos os endereços de localização de recurso de recursos como `<img src="...">`, `background: url(...)`, e `@import` de folha de estilo são resolvidos como dependências do módulo:
 
-Por exemplo, nós temos esta árvore de ficheiro:
+Por exemplo, temos esta árvore de ficheiros:
 
 ```
 -| assets/
@@ -124,13 +127,13 @@ Por exemplo, nós temos esta árvore de ficheiro:
 ----| index.vue
 ```
 
-Se você usar `url('~assets/image.png')` dentro do seu CSS, ele será traduzido para `require('~/assets/image.png')`.
+Se usarmos `url('~assets/image.png')` no nosso ficheiro de folha de estilo, este será traduzido para `require('~/assets/image.png')`.
 
 ::alert{type="warning"}
-O apelido `~/` não será resolvido corretamente dentro de ficheiros CSS. Você deve usar `~assets` (**sem uma barra**) dentro das referências de `url` de CSS, exemplo `background: url("~assets/banner.svg")`
+O pseudónimo `~/` não será resolvido corretamente nos nossos ficheiros de folha de estilo. Devemos utilizar `~assets` (**sem barra**) nas referências de folha de estilo `url`, ou seja, `background: url("~assets/banner.svg")`.
 ::
 
-Se você referenciar aquela imagem dentro do seu `pages/index.vue`:
+Se referenciarmos esta imagem no nosso `pages/index.vue`:
 
 ```html{}[pages/index.vue]
 <template>
@@ -138,21 +141,21 @@ Se você referenciar aquela imagem dentro do seu `pages/index.vue`:
 </template>
 ```
 
-Ela será compilada para:
+Será compilada em:
 
 ```js
 createElement('img', { attrs: { src: require('~/assets/image.png') } })
 ```
 
-Por `.png` não ser um ficheiro JavaScript, o Nuxt configura o webpack para usar [file-loader](https://github.com/webpack/file-loader) e [url-loader](https://github.com/webpack/url-loader) para manipular eles por você.
+Uma vez que `.png` não é um ficheiro de código `.js`, a Nuxt configura a Webpack para utilizar a [`file-loader`](https://github.com/webpack/file-loader) e a [`url-loader`](https://github.com/webpack/url-loader) para os tratar por nós.
 
-Os benefícios desses carregadores são:
+Os vantagens estas carregadoras são:
 
-O `file-loader` permite você designar onde copiar e colocar o ficheiro de recurso, e como nomear ele usando a versão com hash para um cacheamento melhor. Em produção, você tirará proveito de cacheamento de longo período por padrão!
+- A `file-loader` permite-nos designar onde copiar e colocar o ficheiro de recurso, e como nomeá-lo usando baralhos de versão para melhorar o armazenamento transitório. Em produção. beneficiaremos de um armazenamento transitório de longo prazo por predefinição!
 
-O `url-loader` permite você condicionalmente embutir os ficheiros como URLs de dados em base64 se eles forem menores do que um determinado limite. Isto pode reduzir o número de requisições HTTP para ficheiros triviais.
+- A `url-loader` permite-nos inserir condicionalmente ficheiros como endereços de localização de recurso de dados de `base64` se estes forem menores do que um determinado limite. Isto pode reduzir o número de pedidos do protocolo de hipertexto para ficheiros banais. Se um ficheiro for maior do que o limite, regressa automaticamente a `file-loader`.
 
-Para estes dois carregadores, a configuração padrão é:
+Para estas duas carregadoras, a configuração predefinida é:
 
 ```js
 // https://github.com/nuxt/nuxt/blob/2.x-dev/packages/webpack/src/config/base.js#L382-L411
@@ -190,9 +193,9 @@ Para estes dois carregadores, a configuração padrão é:
 }
 ```
 
-O que significa que cada ficheiro abaixo de 1kb será embutido como URL de dado na base64. Caso contrário, a imagem/fonte serão copiados para suas pastas correspondentes (dentro do diretório `.nuxt`) com o nome contendo a versão em hash para um cacheamento melhor.
+O que significa que todos os ficheiros com menos de 1kb serão incluídos como endereço de localização de recurso de dados de `base64`. Caso contrário, a imagem e o tipo de letra serão copiados na sua pasta correspondente (no diretório `.nuxt`) com um nome contendo uma sequência baralhada de caracteres de versão para melhorar o armazenamento transitório.
 
-Quando estiver lançando a sua aplicação com `nuxt`, o seu modelo dentro de `pages/index.vue`:
+Ao lançar a nossa aplicação com `nuxt`, o nosso modelo de marcação em `pages/index.vue`:
 
 ```html{}[pages/index.vue]
 <template>
@@ -206,13 +209,13 @@ Será transformado em:
 <img src="/_nuxt/img/your_image.0c61159.png" />
 ```
 
-Se você quiser mudar as configurações do carregador, use o [build.extend](/docs/configuration-glossary/configuration-build#extend).
+Se quisermos alterar as configurações do carregador, utilizamos a [`build.extend`](/docs/configuration-glossary/configuration-build#extend).
 
-## Os apelidos
+## Pseudónimos
 
-Por padrão o diretório fonte (srcDir) e diretório raiz (rootDir) são o mesmo. Você pode usar o apelido `~` para o diretório fonte. Ao invés de escrever caminhos relativos como `../assets/your_image.png` você pode usar `~/assets/your_image.png`.
+Por predefinição, o diretório de origem (`srcDir`) e o diretório raiz (`rootDir`) são os mesmos. Podemos usar o pseudónimo `~` para o diretório de origem. Ao invés de escrevermos caminhos relativos como `../assets/your_image.png`, podemos usar `~/assets/your_image.png`.
 
-Ambos alcançarão os mesmos resultados.
+Ambas as opções permitem obter os mesmos resultados:
 
 ```html{}[components/Avatar.vue]
 <template>
@@ -223,10 +226,10 @@ Ambos alcançarão os mesmos resultados.
 </template>
 ```
 
-Nós recomendamos usar o `~` como um apelido. `@` continua sendo suportado mas não funcionará em todos casos tais como com imagens de fundo dentro do seu css.
+Recomendamos a utilização do `~` como um pseudónimo. O `@` ainda é suportado, mas não funcionará em todos os casos, como com imagens de fundo no nosso ficheiro de folha de estilo (`.css`).
 
-Você pode usar os apelidos `~~` ou  `@@` para o diretório raiz.
+Podemos utilizar o pseudónimo de `~~` ou `@@` para o diretório raiz.
 
 ::alert{type="info"}
-Dica: No teclado Espanhol você pode acessar o `~` com (`Option` + `ñ`) no Mac OS, ou (`Alt Gr` + `4`) no Windows
+Dica: No teclado espanhol, podemos acessar a `~` com (`Option` + `ñ`) no macOS, ou (`Alt gr` + `4`) no Windows.
 ::

--- a/content/pt/docs/4.directory-structure/3.components.md
+++ b/content/pt/docs/4.directory-structure/3.components.md
@@ -1,20 +1,22 @@
 ---
-title: O diretório components
+title: Diretório de Componentes
 navigation.title: componentes
-description: O diretório components contém seus componentes Vue.js. Os componentes são os que compõe as diferentes partes da sua página e podem ser reutilizados e importados dentro das suas páginas, dos esquemas e até dentro de outros componentes.
+description: O diretório de componentes contém os nossos componentes abstratos. Os componentes constituem as diferentes partes da nossa página e podem ser reutilizados e importados para as nossas páginas, disposições e até para os outros componentes.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/03_components?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório components
 
-O diretório `components` contém seus componentes Vue.js. Os componentes são os que compõe as diferentes partes da sua página e podem ser reutilizados e importados dentro das suas páginas, dos esquemas e até dentro de outros componentes.
+# Diretório de Componentes
+
+O diretório `components` contém os nossos componentes `.vue`. Os componentes constituem as diferentes partes da nossa página e podem ser reutilizados e importados para as nossas páginas, disposições e até para os outros componentes.
 
 ---
+
 ### Requisição de dados
 
-Para acessar dados assíncronos a partir de uma API dentro dos seus componentes você pode usar o método [`fetch()`](/docs/features/data-fetching#o-gatilho-fetch) do Nuxt.
+Para acessar dados assíncronos duma interface de programação de aplicação nos nossos componentes, podemos usar [`fetch()`](/docs/features/data-fetching#a-função-gatilho-fetch) da Nuxt.
 
-Ao verificar o `$fetchState.pending`, nós podemos exibir uma mensagem quando os dados estiverem esperando para serem carregados. Nós podemos também consultar o `$fetchState.error` e exibir uma mensagem de erro se houver um erro na requisição dos dados. Sempre que estivermos usando o método `fetch()`, nós devemos declarar as propriedades apropriadas dentro do método `data()`. Os dados que vierem da requisição podem então ser atribuídos à estas propriedades.
+Ao verificar `$fetchState.pending`, podemos mostrar uma mensagem quando os dados estiverem à espera de serem carregados. Também podemos verificar `$fetchState.error` e mostrar uma mensagem de erro se houver um erro na obtenção dos dados. Ao utilizar a `fetch`, devemos declarar as propriedades corretas em `data()`. Os dados provenientes da obtenção de dados podem então ser atribuídos as estas propriedades:
 
 ```html{}[components/MountainsList.vue]
 <template>
@@ -45,14 +47,14 @@ Ao verificar o `$fetchState.pending`, nós podemos exibir uma mensagem quando os
 ```
 
 ::alert{type="next"}
-Consulte o capítulo no método [fetch()](/docs/features/data-fetching#o-gatilho-fetch) para obter mais detalhes sobre como o fetch funciona.
+Consultar o capítulo sobre a [`fetch()`](/docs/features/data-fetching#a-função-gatilho-fetch) por mais detalhes sobre como a obtenção de dados funciona. 
 ::
 
-## Descoberta de componentes
+## Descoberta de Componentes
 
 :prose-img{src="/img/docs/components.png"}
 
-A partir da versão `v2.13`, o Nuxt pode importar automaticamente os componentes que você usar. Para ativar esta funcionalidade, defina `components: true` dentro da sua configuração:
+Desde a versão `v2.13`, a Nuxt pode importar automaticamente os componentes que usamos. Para ativar esta funcionalidade, definir `components: true` na nossa configuração:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -60,7 +62,7 @@ export default {
 }
 ```
 
-Qualquer componente dentro do diretório `~/components` podem então ser usados em todas as suas páginas, esquemas (e outros componentes) sem a necessidade de explicitamente importar eles.
+Quaisquer componentes no diretório `~/components` podem então ser usados em todas as nossas páginas, disposições (e outros componentes) sem a necessidade de importá-los explicitamente:
 
 ```bash
 | components/
@@ -79,12 +81,12 @@ Qualquer componente dentro do diretório `~/components` podem então ser usados 
 ```
 
 ::alert{type="next"}
-Aprenda mais sobre o módulo de componentes [dentro da documentação da descoberta de componentes](/docs/features/component-discovery) e [dentro deste artigo de anúncio](/tutorials/improve-your-developer-experience-with-nuxt-components).
+Saber mais sobre o módulo de componentes na [documentação da descoberta de componentes](/docs/features/component-discovery) e [neste artigo de anúncio](/tutorials/improve-your-developer-experience-with-nuxt-components).
 ::
 
-### Importação dinâmica
+### Importações Dinâmicas
 
-Para importar dinamicamente um componente, também conhecido como carregamento preguiçoso de um componente, tudo o que você precisa fazer é adicionar o prefixo `Lazy` dentro dos seus modelos.
+Para importar dinamicamente um componente, também conhecido como carregamento preguiçoso de um componente, tudo o que precisamos de fazer é adicionar o prefixo `Lazy` nos nossos modelos de marcação de hipertexto: 
 
 ```html{}[layouts/default.vue]
 <template>
@@ -96,7 +98,7 @@ Para importar dinamicamente um componente, também conhecido como carregamento p
 </template>
 ```
 
-Ao usar o prefixo lazy você pode também dinamicamente importar um componente quando um evento for acionado.
+Ao utilizar o prefixo `lazy`, também podemos importar dinamicamente um componente quando um evento é acionado:
 
 ```html{}[pages/index.vue]
 <template>
@@ -118,9 +120,9 @@ export default {
 </script>
 ```
 
-### Diretórios aninhados
+### Diretórios Encaixados
 
-Se você tiver componentes dentro de diretórios aninhados tais como:
+Se tivermos componentes em diretórios encaixados tais omo:
 
 ```bash
 components/
@@ -129,13 +131,13 @@ components/
          CustomButton.vue
 ```
 
-O nome do componente será baseado no seu próprio caminho do diretório e nome de ficheiro. Portanto, o componente será:
+O nome do componente será baseado no seu próprio caminho, diretório e nome de ficheiro. Por conseguinte, o componente será:
 
 ```html
 <BaseFooCustomButton />
 ```
 
-Se nós quisermos usar ele como `<CustomButton />` enquanto mantém a estrutura do diretório, nós podemos adicionar o diretório de `CustomButton.vue` dentro de `nuxt.config.js`.
+Se quisermos usá-lo como `<CustomButton />` mantendo a estrutura de diretório, podemos adicionar o diretório do `CustomButton.vue` no `nuxt.config.js`:
 
 ```bash{}[nuxt.config.js]
 components: {
@@ -146,16 +148,16 @@ components: {
 }
 ```
 
-E agora podemos usar o `<CustomButton />` ao invés de `<BaseFooCustomButton />`.
+E agora podemos usar `<CustomButton />` em vez de `<BaseFooCustomButton />`:
 
 ```html{}[pages/index.vue]
 <CustomButton />
 ```
 
 ::alert{type="next"}
-Consulte a documentação da [propriedade components](/docs/configuration-glossary/configuration-components) para conhecer outros métodos de controle de nome do componente.
+Consultar a [propriedade `components`](/docs/configuration-glossary/configuration-components) por outros métodos de controlo do nome do componente. 
 ::
 
 ::alert{type="info"}
-Saiba mais sobre o [módulo de componentes](/tutorials/improve-your-developer-experience-with-nuxt-components).
+Saber mais sobre o [módulo de componentes](/tutorials/improve-your-developer-experience-with-nuxt-components).
 ::

--- a/content/pt/docs/4.directory-structure/4.content.md
+++ b/content/pt/docs/4.directory-structure/4.content.md
@@ -1,28 +1,29 @@
 ---
-title: O diretório content
+title: Diretório de Conteúdo
 navigation.title: content
-description: Dê poderes a sua aplicação Nuxt com o módulo @nuxt/content onde você pode escrever dentro de um diretório content/ e requisitar os seus ficheiros markdown, json, yaml e cs através de uma API parecida com o MongoDB, agindo como um CMS Headless baseado em Git.
+description: Enriquece a nossa aplicação de Nuxt com o módulo de conteúdo onde podemos escrever num diretório de conteúdo e buscar os nossos ficheiros de Markdown, JSON, YAML e CSV através duma interface de programação de aplicação tipo MongoDB, atuando como um sistema de gestão de conteúdo sem cabeça baseado em Git.
 category: directory-structure
 ---
-# O diretório content
 
-Dê poderes sua aplicação Nuxt com o módulo `@nuxt/content` onde você pode escrever dentro de um diretório `content/` e requisitar os seus ficheiros markdown, json, yaml e csv através de uma API parecida com o MongoDB, agindo como um **CMS Headless baseado em Git**.
+# Diretório de Conteúdo
+
+Enriquece a nossa aplicação de Nuxt com o módulo `@nuxt/content` onde podemos escrever num diretório `content/` e buscar os nossos ficheiros de `.md`, `.json`, `.yml` e `.csv` através duma interface de programação de aplicação tipo MongoDB, atuando como um **sistema de gestão de conteúdo sem cabeça baseado em Git**.
 
 ---
 
 ![](/img/docs/nuxt-content.svg)
 
-### Recarregamento instantâneo em desenvolvimento
+### Recarregar Instantaneamente em Desenvolvimento
 
-O módulo de conteúdo é extremamente rápido quando vem para o recarregamento instantâneo em desenvolvimento por não ter que passar pelo webpack sempre que você fizer mudanças em seus ficheiros markdown. Você pode também ouvir o evento `content:update` e criar um plugin que em todo momento que você atualizar um ficheiro dentro do seu diretório de conteúdo ele despachará por exemplo um método fetchCategories.
+O módulo de conteúdo é muito rápido quando se trata de recarregar instantaneamente em desenvolvimento, devido a não ter que passar pela Webpack quando fazemos alterações nos nossos ficheiros de Markdown. Também podemos ouvir o evento `content:update` e criar uma extensão para que, sempre que atualizarmos um ficheiro no nosso diretório de conteúdo, despache um método `fetchCategories`, por exemplo:
 
 ::alert{type="next"}
-[Consulte a documentação do módulo de conteúdo para obter mais detalhes](https://content.nuxtjs.org/advanced#handling-hot-reload)
+[Consultar a documentação do módulo de conteúdo por mais detalhes](https://content.nuxtjs.org/advanced#handling-hot-reload).
 ::
 
-### Exibindo o conteúdo
+### Exibir o Conteúdo
 
-Você pode diretamente usar o componente `<nuxt-content>` dentro do seu modelo para exibir o corpo da página.
+Podemos usar o componente `<nuxt-content>` diretamente no nosso modelo de marcação de hipertexto para mostrar o corpo da página: 
 
 ```html{}[pages/blog/_slug.vue]
 <template>
@@ -33,14 +34,14 @@ Você pode diretamente usar o componente `<nuxt-content>` dentro do seu modelo p
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/displaying#component) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/displaying#component) por mais detalhes.
 ::
 
-### Estilizando o seu conteúdo
+### Estilizar o Nosso Conteúdo
 
-Dependendo do que você está usando para desenhar a sua aplicação, voce pode precisar escrever alguns estilos para exibir o markdown de maneira decente. 
+Dependendo do que estivermos a utilizar para conceber a nossa aplicação, poderemos ter de escrever algum estilo para apresentar corretamente a Markdown.
 
-O componente `<nuxt-content>` irá automaticamente adicionar uma classe `.nuxt-content`, você pode usar ela para personalizar seus estilos.
+O componente `<nuxt-content>` adicionará automaticamente uma classe `.nuxt-content`, podemos usá-la para personalizar os nossos estilos:
 
 ```html
 <style>
@@ -55,12 +56,12 @@ O componente `<nuxt-content>` irá automaticamente adicionar uma classe `.nuxt-c
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/displaying#style) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/displaying#style) por mais detalhes.
 ::
 
-### Manipular ficheiros markdown, csv, yaml, json(5)
+### Manipular Ficheiros `.md`, `.csv`, `.yaml`, `.json`
 
-Este módulo converte o seus ficheiros `.md` em uma estrutura de árvore JSON AST, guardada dentro de uma variável `body`. Você pode também adicionar um bloco de assunto dianteiro em YAML aos seus ficheiros markdown ou um ficheiro `.yaml` que será injetado dentro do documento. Você pode também adicionar um ficheiro json/json5 que pode também ser injetado dentro do documento. E você pode usar um ficheiro `.csv` onde as linhas serão atribuídas a variável `body`.
+Este módulo converte os nossos ficheiros `.md` numa estrutura de árvore de sintaxe abstrata de notação de objeto de JavaScript, armazenada numa variável de corpo. Também podemos adicionar um bloco de capa de YAML aos nossos ficheiros de Markdown ou a um ficheiro `.yml` que será injetado no documento. Também podemos adicionar um ficheiro `json/json5` que também pode ser injetado no documento. E podemos utilizar um ficheiro `.csv` onde as linhas serão atribuídas à variável do corpo:
 
 ```md
 ---
@@ -70,12 +71,12 @@ description: Learning how to use @nuxt/content to create a blog
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#markdown) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#markdown) por mais detalhes.
 ::
 
-### Componentes do vue dentro do markdown
+### Componentes `.vue` no `.md`
 
-Você pode usar componentes Vue diretamente dentro do seus ficheiros markdown. No entanto você precisará usar seus componentes em kebab case e não pode usar marcadores com auto fechamento.
+Podemos utilizar componentes `.vue` diretamente nos nossos ficheiros `.md`. No entanto, teremos de utilizar os nossos componentes como caixas de espetadas (nomes separados por traço ou hífen) e não podemos utilizar os marcadores de fecho automático:
 
 ```html{}[components/global/InfoBox.vue]
 <template>
@@ -94,12 +95,12 @@ Você pode usar componentes Vue diretamente dentro do seus ficheiros markdown. N
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#vue-components) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#vue-components) por mais detalhes.
 ::
 
-### API totalmente pesquisáveis
+### Interface de Programação de Aplicação Totalmente Pesquisáveis
 
-Você pode usar `$content()` para listar, filtrar e pesquisar seus conteúdo facilmente.
+Podemos utilizar a `$content()` para listar, filtrar e pesquisar o nosso conteúdo facilmente:
 
 ```html{}[pages/blog/index.vue]
 <script>
@@ -119,12 +120,12 @@ Você pode usar `$content()` para listar, filtrar e pesquisar seus conteúdo fac
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#methods) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#methods) por mais detalhes.
 ::
 
-### Artigos anteriores e próximos artigos
+### Artigos Anteriores e Posteriores
 
-O módulo de conteúdo inclui um método `.surround(slug)`, é assim que você recebe com facilidade os artigos anteriores e próximos.
+O módulo de conteúdo inclui um método `.surround(slug)` para podermos obter facilmente os artigos anteriores e posteriores:
 
 ```js
 async asyncData({ $content, params }) {
@@ -149,12 +150,12 @@ async asyncData({ $content, params }) {
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#surroundslug-options) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#surroundslug-options) por mais detalhes.
 ::
 
-### Pesquisa completa de texto
+### Pesquisa de Texto Integral
 
-O módulo de conteúdo vem com uma pesquisa completa de texto assim você pode facilmente pesquisar ao longo de seus ficheiros markdown sem ter que instalar nada.
+O módulo de conteúdo vem com uma pesquisa de texto completo, pelo que podemos pesquisar facilmente nos nossos ficheiros `.md` sem ter de instalar nada:
 
 ```html{}[components/AppSearchInput.vue]
 <script>
@@ -182,12 +183,12 @@ O módulo de conteúdo vem com uma pesquisa completa de texto assim você pode f
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#searchfield-value) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/fetching#searchfield-value) por mais detalhes.
 ::
 
-### Destacando a sintaxe
+### Realce de Sintaxe
 
-Este módulo envolve automaticamente o bloco de código e aplica as classes do [Prism](https://prismjs.com/). Você pode também adicionar uma tema diferente do Prism ou desativar ele totalmente.
+Este módulo embrulha automaticamente os blocos de código e aplica classes da [Prism](https://prismjs.com/). Também podemos adicionar um tema de Prism diferente ou desativá-lo completamente:
 
 ::code-group
 ```bash [Yarn]
@@ -209,20 +210,20 @@ content: {
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#syntax-highlighting) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#syntax-highlighting) por mais detalhes.
 ::
 
-### Estender o parseamento do markdown
+### Estender a Análise Sintática da Markdown
 
-Originalmente o markdown não suporta destacamento de linhas dentro de um bloco de código nem de nomes de ficheiros. O módulo de conteúdo permite isto com sua própria sintaxe personalizada. Linhas numeradas são adicionadas a tag `pre` dentro dos atributos data-line e o nome do ficheiro será convertido para um `span` com uma classe `filename`, assim você pode estilizar ela.
+Originalmente, a Markdown não suporta o realce de linhas em blocos de código nem de nomes de ficheiros. O módulo de conteúdo permite-o com a sua própria sintaxe personalizada. Os números de linha são adicionados ao marcador `pre` nos atributos `data-line` e o nome do ficheiro será convertido para um `span` com uma classe `filename`, para podermos estilizá-lo:
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#codeblocks) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#codeblocks) por mais detalhes.
 ::
 
-### Geração de tabela de conteúdos
+### Geração de Índices
 
-Uma propriedade do tipo array toc(Table of Contents, Table de Conteúdos) será injetada dentro do seu documento, listando todos os cabeçalhos com seus títulos e ids, assim você pode ligar a eles.
+Uma propriedade do tipo vetor `toc` (abreviação de índice em Inglês) será injetada no nosso documento, listando todos os cabeçalhos com os seus títulos e identificadores, para podermos estabelecer uma hiperligação a estes:
 
 ```html{}[pages/blog/_slug.vue]
 <nav>
@@ -235,53 +236,53 @@ Uma propriedade do tipo array toc(Table of Contents, Table de Conteúdos) será 
 ```
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#table-of-contents) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/writing#table-of-contents) por mais detalhes.
 ::
 
-### A poderosa API construtora de consulta (parecida com MongoDB)
+### Interface de Programação de Aplicação Construtora de Consulta Poderosa (Parecida com a MongoDB).
 
-O módulo de conteúdo vem com uma poderosa API construtora de consulta semelhante ao MongoDB que permite você facilmente ver o JSON de cada diretório em `http://localhost:3000/_content/`. O alvo final é acessível as requisições GET e POST, assim você pode usar parâmetros de consulta.
+O módulo de conteúdo vem com uma poderosa interface de programação de aplicação construtora de consulta semelhante a MongoDB, que permite-nos ver facilmente a notação de objeto de JavaScript de cada diretório em `http://localhost:3000/_content/`. O destino está acessível nas requisições `GET` e `POST`, pelo que podemos utilizar parâmetros de consulta:
 
 `http://localhost:3000/_content/articles?only=title&only=description&limit=10`
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced/#api-endpoint) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced/#api-endpoint) por mais detalhes.
 ::
 
-### Estender com gatilhos
+### Estender com as Funções Gatilhos
 
-Você pode usar gatilhos para estender o módulo, assim você pode adicionar dados a um documento antes dele ser guardado.
+Podemos utilizar as funções gatilhos para estender o módulo de modo a podermos adicionar dados a um documento antes de este ser armazenado.
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced#hooks) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced#hooks) por mais detalhes.
 ::
 
-### Integração com o @nuxtjs/feed
+### Integração com `@nuxtjs/feed`
 
-No caso de artigos, o conteúdo pode ser usado para gerar alimentador de noticias usando o módulo [@nuxtjs/feed](https://www.npmjs.com/package/@nuxtjs/feed).
+No caso dos artigos, o conteúdo pode ser utilizado para gerar rações (também conhecidos por `feeds`) de notícias utilizando o módulo [`@nuxtjs/feed`](https://www.npmjs.com/package/@nuxtjs/feed).
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/integrations/#nuxtjsfeed) para obter mais detalhes
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/integrations/#nuxtjsfeed) por mais detalhes.
 ::
 
-### Suporte a geração de site estático
+### Suporte à Geração de Sítios Estáticos
 
-O módulo de conteúdo funciona com geração de site estático usando o `nuxt generate`. Todas as rotas serão automaticamente gerada graças ao funcionalidade rastreadora do Nuxt.
+O módulo de conteúdo funciona com a geração de sítios estáticos ao utilizar `nuxt generate`. Todas as rotas serão geradas automaticamente graças a funcionalidade de rastreio da Nuxt.
 
 ::alert{type="warning"}
-Se estiveres usando o Nuxt < 2.13 e você precisa especificar as rotas dinâmicas, você pode fazer isso usando programaticamente a propriedade generate e @nuxt/content.
+Se utilizarmos a Nuxt <2.13 e precisarmos de especificar as rotas dinâmicas, podemos fazê-lo ao utilizar a propriedade `generate` e ao utilizar a `@nuxt/content` programaticamente.
 ::
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced#programmatic-usage) para obter mais detalhes sobre o uso programático
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/advanced#programmatic-usage) por mais detalhes sobre o uso programático.
 ::
 
-### O que segue
+### O Que Se Segue?
 
 ::alert{type="next"}
-Consulte nosso tutorial em [How to Create a Blog with Nuxt Content](/tutorials/creating-blog-with-nuxt-content)
+Consultar o nosso tutorial sobre [Como Criar um Blogue com Módulo de Conteúdo da Nuxt](/tutorials/creating-blog-with-nuxt-content).
 ::
 
 ::alert{type="next"}
-Consulte a [documentação do módulo de conteúdo](https://content.nuxtjs.org/) para uso mais avançados e exemplos
+Consultar a [documentação do módulo de conteúdo](https://content.nuxtjs.org/) por uso mais avançado e exemplos.
 ::

--- a/content/pt/docs/4.directory-structure/5.dist.md
+++ b/content/pt/docs/4.directory-structure/5.dist.md
@@ -1,27 +1,28 @@
 ---
-title: O diretório dist
+title: Diretório de Distribuição
 navigation.title: dist
-description: A pasta dist, forma abreviada para pasta de distribuição, é dinamicamente gerada quando se usa os comandos nuxt generate e inclui os ficheiros HTML e assets gerados e prontos para produção que são necessários para desdobrar e executar sua aplicação Nuxt estaticamente gerada.
+description: A pasta de distribuição é gerada dinamicamente ao usar os comandos de geração e inclui os ficheiro de marcação de hipertexto prontos para produção e os recursos necessários para implantar e executar a nossa aplicação de Nuxt gerada estaticamente.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/05_dist?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório dist
 
-A pasta `dist`, forma abreviada para pasta de *distribuition (distribuição)*, é dinamicamente gerada quando se usa os comandos `nuxt generate` e inclui os ficheiros HTML e assets gerados e prontos para produção que são necessários para desdobrar e executar sua aplicação Nuxt estaticamente gerada.
+# Diretório de Distribuição
+
+A pasta `dist`, abreviação de pasta de distribuição, é gerada automaticamente ao usar os comandos `nuxt generate` e inclui os ficheiros `.html` prontos para produção e os recursos necessários para implantar e executar a nossa aplicação de Nuxt gerada estaticamente.
 
 ---
 
-### Desdobrando
+### Implantação
 
-Esta é a pasta que você precisa **carregar para hospedagem estática** visto que ele contém seus ficheiros HTML e assets gerados e prontos para produção.
+Esta é a pasta que precisamos de **carregar para a hospedagem estática**, uma vez que contém os nossos ficheiros `.html` e recursos prontos para produção.
 
 ::alert{type="warning"}
-O diretório `dist` não deve ser enviado para o seu sistema de controlo de versão e deve ser ignorado através do seu `.gitignore` visto que ele será gerado automaticamente toda vez que você executar o `nuxt generate`.
+O diretório `dist` não deve ser submetido ao nosso sistema de controlo de versão e deve ser ignorado através do nosso `.gitignore`, pois este será gerado automaticamente sempre que executarmos o `nuxt generate`.
 ::
 
-### A propriedade dir
+### A Propriedade `dir`
 
-A pasta dist é nomeada dist por padrão mas pode ser configurada dentro do seu ficheiro `nuxt.config.js`.
+A pasta de distribuição é nomeada `dist` por predefinição, mas pode ser configurada no nosso ficheiro `nuxt.config.js`:
 
 ```js{}[nuxt.config.js]
 generate: {
@@ -30,12 +31,12 @@ generate: {
 ```
 
 ::alert{type="warning"}
-Se você mudar a sua pasta dist então você precisará adicionar ele ao seu sistema de controlo de versão assim o git ignorará ele.
+Se alterarmos a nossa pasta de distribuição, então teremos de a adicionar ao nosso controlo de versão para que a `git` a ignore.
 ::
 
-### A propriedade subFolders
+### A Propriedade `subFolders`
 
-O Nuxt coloca todas as suas páginas geradas dentro de uma pasta por padrão, no entanto você pode mudar isso se você quiser ao modificar o `nuxt.config.js` e mudando o subFolders para ser false.
+A Nuxt coloca todas as nossas páginas geradas numa pasta por predefinição, porém podemos mudar isto se quisermos modificando o `nuxt.config.js` e alterando a `subFolders` para `false`:
 
 ```js{}[nuxt.config.js]
 generate: {
@@ -43,16 +44,16 @@ generate: {
 }
 ```
 
-### A propriedade fallback
+### A Propriedade `fallback`
 
-Quando estiver fazendo o deploy do seu site você precisará certificar-se que o caminho para o HTML do fallback está corretamente definido. Ele deve ser definido como a página de erro uma vez que as rotas desconhecidas são renderizadas via Nuxt.
+Ao implantar o nosso sítio, teremos de certificar-nos de que o caminho da marcação de hipertexto de retrocesso está definido corretamente. Esta deve ser definida como a página de erro para as rotas desconhecidas serem desenhadas através da Nuxt. Se não for definida, a Nuxt utilizará o valor predefinido, que é `200.html`.
 
-Quando estiver executando uma aplicação de página única faz mais sentido usar o 200.html assim ele é o único ficheiro necessário, visto que nenhuma das outras rotas é gerada.
+Ao executar uma aplicação de página única, faz mais sentido utilizar `200.html`, por ser o único ficheiro necessário, uma vez que não são gerados outras rotas.
 
-Quando estiver trabalhando com páginas geradas estaticamente, é recomendado usar o 404.html para páginas de erro.
+Ao trabalhar com páginas geradas estaticamente, recomenda-se a utilização de um `404.html` para as páginas de erro.
 
 ::alert{type="warning"}
-Dependendo de onde você estiver hospedando o seu sítio, você pode ter que usar o `200.html` ou o `404.html`. Consulte com o seu provedor de hospedagem. O Netlify, por exemplo usa o `404.html`.
+Dependendo de onde hospedamos o nosso sítio, podemos ter de usar `200.html` ou `400.html`. Precisamos consultar o nosso fornecedor de hospedagem. A Netlify, por exemplo, utiliza o `404.html`.
 ::
 
 ```js{}[nuxt.config.js]
@@ -63,9 +64,9 @@ export default {
 }
 ```
 
-### A propriedade exclude
+### A Propriedade `excludes`
 
-Você pode excluir páginas de serem geradas ao usar a propriedade `excludes` do `generate`. Ao invés de serem geradas como uma página estática ela voltará a ser uma página de uma aplicação de página única e somente será renderizada no lado do cliente.
+Podemos excluir páginas de serem geradas ao utilizar a propriedade `excludes` de `generate`. Em vez de ser gerada como uma página estática, será uma página de aplicação de página única e só será desenhada no lado do cliente:
 
 ```js{}[nuxt.config.js]
 generate: {
@@ -74,5 +75,5 @@ generate: {
 ```
 
 ::alert{type="info"}
-Você pode também usar aqui uma expressão regular para excluir páginas que começam ou terminam com uma palavra em particular
+Também podemos utilizar uma expressão de expressão regular nesta propriedade para excluir páginas que começam ou terminam com uma determinada palavra.
 ::

--- a/content/pt/docs/4.directory-structure/6.layouts.md
+++ b/content/pt/docs/4.directory-structure/6.layouts.md
@@ -1,25 +1,26 @@
 ---
-title: O diretório layouts
+title: Diretório de Disposições
 navigation.title: layouts
-description: Os esquemas são de uma grande ajuda sempre que você quiser mudar a aparência e a emoção da sua aplicação Nuxt. Seja quando você quiser incluir uma barra lateral ou ter um esquema distinto para o mobile e desktop.
+description: As disposições são uma grande ajuda quando queremos alterar o aspeto e a sensação da nossa aplicação de Nuxt. Quer queiramos incluir uma barra lateral ou ter disposições distintas para telemóvel e computador.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/07_layouts?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório layouts
 
-Os esquemas (layouts) são de uma grande ajuda sempre que você quiser mudar a aparência e a emoção da sua aplicação Nuxt. Seja quando você quiser incluir uma barra lateral ou ter um esquema distinto para o mobile e desktop.
+# Diretório de Disposições
+
+As disposições são uma grande ajuda quando queremos alterar o aspeto e a sensação da nossa aplicação de Nuxt. Quer queiramos incluir uma barra lateral ou ter disposições distintas para telemóvel e computador de ambiente de trabalho.
 
 ---
 
 ::alert{type="warning"}
-Este diretório não pode ser renomeado sem configuração extra.
+Este diretório não pode ser renomeado sem configuração adicional.
 ::
 
-### O esquema padrão
+### Disposição Predefinida
 
-Você pode estender o esquema principal ao adicionar um ficheiro `layouts/default.vue`. Ele será usado para todas as páginas que não tiverem um esquema especificado. Certifique-se de adicionar o componente `<Nuxt>` quando estiver criando um esquema para efetivamente incluir o componente de página.
+Podemos estender a disposição principal ao adicionar um ficheiro `layouts/default.vue`. Será utilizado para todas as páginas que não tenham uma disposição especificada. Certificamo-nos de adicionar o componente `<Nuxt>` ao criar uma disposição para incluir efetivamente o componente de página.
 
-Todo o que você precisa dentro do seu esquema são três linhas de código que renderizarão o componente da página.
+Tudo o que precisamos na nossa disposição são três linhas de código que desenharão o componente de página:
 
 ```html{}[layouts/default.vue]
 <template>
@@ -27,7 +28,7 @@ Todo o que você precisa dentro do seu esquema são três linhas de código que 
 </template>
 ```
 
-Você pode adicionar aqui mais componentes tais como Navegação (Navigation), Cabeçalho (Header), Rodapé (Footer) etc.
+Podemos adicionar mais componentes neste exemplo, como Navegação (`Navigation`), Cabeçalho (`Header`), Rodapé (`Footer`), etc:
 
 ```html{}[layouts/default.vue]
 <template>
@@ -40,14 +41,14 @@ Você pode adicionar aqui mais componentes tais como Navegação (Navigation), C
 ```
 
 ::alert{type="info"}
-Se você tiver a propriedade [components definida para `true`](/docs/directory-structure/components) então não há necessidade de adicionar qualquer declaração `import` para os seus componentes.
+Se tivermos a propriedade [`components` definida como `true`](/docs/directory-structure/components), então não existe necessidade de adicionar nenhuma instrução de importação (`import`) para os nossos componentes.
 ::
 
-### O esquema personalizado
+### Disposição Personalizada
 
-Todo ficheiro de (_alto-nível_) dentro do diretório `layouts` criará um esquema personalizado acessível com a propriedade `layout` dentro dos componentes da página.
+Cada ficheiro (de _alto nível_) no diretório `layouts` criará uma disposição personalizada acessível com a propriedade `layout` nos componentes de página.
 
-Vamos dizer que queremos criar um esquema de blogue e guardar ele em `layouts/blog.vue`:
+Digamos que queremos criar uma disposição de blogue e guardá-la em `layouts/blog.vue`:
 
 ```html{}[layouts/blog.vue]
 <template>
@@ -58,7 +59,7 @@ Vamos dizer que queremos criar um esquema de blogue e guardar ele em `layouts/bl
 </template>
 ```
 
-Depois você tem de dizer para as páginas usarem o seu esquema personalizado
+Depois, temos de dizer às páginas para utilizarem a nossa disposição personalizada:
 
 ```js{}[pages/posts.vue]
 <script>
@@ -72,17 +73,17 @@ export default {
 </script>
 ```
 
-## A página de erro
+## Página de Erro
 
-A página de erro é um *componente de página* que é sempre exibido quando um erro ocorre (que não seja lançado no lado do servidor).
+A página de erro é um *componente de página*, o qual é sempre apresentado quando ocorre um erro (que não é lançado no lado do servidor).
 
 ::alert{type="warning"}
-Embora este ficheiro esteja posto dentro da pasta `layouts`, ele deve ser tratado como uma página.
+Embora este ficheiro seja colocado na pasta `layouts`, deve ser tratado como uma página.
 ::
 
-Como já foi mencionado acima, este esquema é especial e você não deve incluir o `<Nuxt>` dentro do seu modelo (template). Você deve ver este esquema como um componente exibido quando um erro ocorre (`404`, `500` etc). Similar aos outros componentes de página, você pode definir um esquema personalizado para a página de erro.
+Conforme mencionado acima, esta disposição é especial, e não devemos incluir `<Nuxt>` dentro do seu modelo de marcação de hipertexto. Devemos ver esta disposição como um componente exibido quando ocorre um erro (`404`, `500`, etc.). À semelhança de outros componentes de página, também podemos definir uma disposição personalizado para a página de erro, da maneira habitual.
 
-Você pode personalizar a página de erro ao adicionar um ficheiro `layouts/error.vue`:
+Podemos personalizar a página de erro ao adicionar um ficheiro `layouts/error.vue`:
 
 ```js{}[layouts/error.vue]
 <template>
@@ -96,11 +97,11 @@ Você pode personalizar a página de erro ao adicionar um ficheiro `layouts/erro
 <script>
 export default {
   props: ['error'],
-  layout: 'blog' // você pode definir um esquema personalizado para a página de erro
+  layout: 'blog' // podemos definir uma disposição personalizada para a página de erro.
 }
 </script>
 ```
 
 ::alert{type="info"}
-O código-fonte da página de erro padrão está [disponível no GitHub](https://github.com/nuxt/nuxt/blob/2.x-dev/packages/vue-app/template/components/nuxt-error.vue).
+O código-fonte da página de erro predefinida está [disponível na GitHub](https://github.com/nuxt/nuxt/blob/2.x-dev/packages/vue-app/template/components/nuxt-error.vue).
 ::

--- a/content/pt/docs/4.directory-structure/7.middleware.md
+++ b/content/pt/docs/4.directory-structure/7.middleware.md
@@ -1,42 +1,43 @@
 ---
-title: O diretório middleware
+title: Diretório Intermediário
 navigation.title: middleware
-description: O diretório middleware contém suas aplicações intermediárias. O intermediário permite você definir funções personalizadas que podem ser executadas antes da renderização, seja de uma página ou um grupo de páginas (esquema).
+description: O diretório intermediário contém o intermediário da nossa aplicação. O intermediário permite-nos definir funções personalizadas que podem ser executadas antes de desenhar uma página ou grupo de páginas (disposição).
 category: directory-structure
 csb_link_anonymous: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/09_middleware_anonymous?fontsize=14&hidenavigation=1&theme=dark
 csb_link_named: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/09_middleware_named?fontsize=14&hidenavigation=1&theme=dark
 csb_link_router: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/09_middleware_router?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório middleware
 
-O diretório `middleware` contém suas aplicações intermediárias. O intermediário permite você definir funções personalizadas que podem ser executadas antes da renderização, seja de uma página ou um grupo de páginas (esquema).
+# Diretório Intermediário
+
+O diretório `middleware` contém o intermediário da nossa aplicação. O intermediário permite-nos definir funções personalizadas que podem ser executadas antes de desenhar uma página ou grupo de páginas (disposição).
 
 ---
 
-O intermediário partilhado deve ser colocado dentro do diretório `middleware/`. O nome do ficheiro será o nome do intermediário (`middleware/auth.js` será o intermediário `auth`). Você pode também definir intermediário específico da página ao usar uma função diretamente, vê [intermediário anónimo](/examples/middlewares/anonymous).
+O intermediário partilhado deve ser colocado no diretório `middleware/`. O nome do ficheiro será o nome do intermediário (`middleware/auth.js` será o intermediário `auth`). Também podemos definir o intermediário específico da página ao utilizar diretamente uma função, consultar [intermediário anónimo](/examples/middlewares/anonymous).
 
-Um intermediário recebe [o contexto](/docs/internals-glossary/context) como o primeiro argumento.
+Um intermediário recebe [o contexto](/docs/internals-glossary/context) como primeiro argumento.
 
 ```js{}[middleware/user-agent.js]
 export default function (context) {
-  // Adiciona a propriedade `userAgent` ao contexto
+  // Adicionar a propriedade `userAgent` ao contexto.
   context.userAgent = process.server
     ? context.req.headers['user-agent']
     : navigator.userAgent
 }
 ```
 
-No modo universal, os intermediários serão chamados uma vez no lado do servidor (na primeira requisição para a aplicação Nuxt, exemplo de quando estiverem diretamente acessando a aplicação ou atualizado a página) e no lado do cliente quando estiverem navegando para as rotas adiante. Com `ssr: false`, o intermediário será chamado no lado do cliente em ambas situações.
+No modo universal, os intermediários serão chamados uma vez no lado do servidor (no primeiro pedido à aplicação de Nuxt, por exemplo, ao acessar diretamente à aplicação ou ao atualizar a página) e no lado do cliente ao navegar para outras rotas. Com `ssr: false`, os intermediários serão chamados no lado do cliente em ambas as situações.
 
-O intermédio será executado em série nesta ordem:
+O intermédio será executado em série, por esta ordem:
 
-1. `nuxt.config.js` (na ordem dentro do ficheiro)
-2. Esquemas correspondidos
-3. Páginas correspondidas
+1. `nuxt.config.js` (pela ordem no ficheiro).
+2. Disposições correspondentes.
+3. Páginas correspondentes.
 
-## O intermediário do roteador
+## Intermediário da Rota
 
-Um intermediário pode ser assíncrono. Para fazer isso retorne uma `Promise` ou usar async/await.
+Um intermediário pode ser assíncrono. Para isto, retornamos uma `Promise` ou utilizar `async` e `await`:
 
 ```js{}[middleware/stats.js]
 import http from 'http'
@@ -48,7 +49,7 @@ export default function ({ route }) {
 }
 ```
 
-Depois, dentro do seu `nuxt.config.js`, use a chave `router.middleware`.
+Depois, no nosso `nuxt.config.js`, usamos a chave `router.middleware`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -58,9 +59,9 @@ export default {
 }
 ```
 
-Agora o intermediário `stats` será chamado para toda mudança de rota.
+Agora, o intermediário `stats` será chamado para cada mudança da rota.
 
-Você pode adicionar o seu intermediário (até mesmo vários) também para um esquema ou página específica.
+Também podemos adicionar o nosso intermediário (mesmo múltiplo) a uma disposição ou página específica.
 
 ```js{}[pages/index.vue / layouts/default.vue]
 export default {
@@ -68,13 +69,13 @@ export default {
 }
 ```
 
-## Intermediário nomeado
+## Intermediário Nomeado
 
-Você pode criar o intermediário nomeado ao criar um ficheiro dentro do diretório `middleware/`, o nome do ficheiro será o nome do intermediário.
+Podemos criar um intermediário nomeado ao criar um ficheiro no diretório `middleware/`, o nome do ficheiro será o nome do intermediário:
 
 ```js{}[middleware/authenticated.js]
 export default function ({ store, redirect }) {
-  // Se o usuário não estiver autenticado
+  // Se o utilizador não estiver autenticado.
   if (!store.state.authenticated) {
     return redirect('/login')
   }
@@ -93,9 +94,9 @@ export default function ({ store, redirect }) {
 </script>
 ```
 
-## Intermediário anónimo
+## Intermediário Anónimo
 
-Se você precisar usar um intermediário somente para uma página específica, você pode diretamente usar uma função para isso (ou um arranjo de funções):
+Se precisarmos de utilizar um intermediário exclusivo para uma página específica, podemos utilizar diretamente uma função para a mesma (ou um vetor de funções):
 
 ```html{}[pages/secret.vue]
 <template>
@@ -105,7 +106,7 @@ Se você precisar usar um intermediário somente para uma página específica, v
 <script>
   export default {
     middleware({ store, redirect }) {
-      // Se o usuário não estiver autenticado
+      // Se o utilizador não estiver autenticado.
       if (!store.state.authenticated) {
         return redirect('/login')
       }

--- a/content/pt/docs/4.directory-structure/8.modules.md
+++ b/content/pt/docs/4.directory-structure/8.modules.md
@@ -1,49 +1,50 @@
 ---
-title: O diretório modules
-navigation.title: módulos
-description: O Nuxt fornece um sistema de módulo de alta ordem que torna possível estender o núcleo. Os módulos são funções que são chamados sequencialmente sempre o Nuxt estiver iniciando.
+title: Diretório de Módulos
+navigation.title: modules
+description: A Nuxt fornece um sistema de módulo de ordem superior que permite estender o núcleo. Os módulos são funções chamadas sequencialmente ao inicializar a Nuxt.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/10_modules?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório modules
 
-O Nuxt fornece um sistema de módulo de alta ordem que torna possível estender o núcleo. Os módulos são funções que são chamados sequencialmente sempre o Nuxt estiver iniciando.
+# Diretório de Módulos
+
+A Nuxt fornece um sistema de módulo de ordem superior que permite estender o núcleo. Os módulos são funções chamadas sequencialmente ao inicializar a Nuxt.
 
 ---
 
-## Explorando os módulos do Nuxt
+## Explorar os Módulos da Nuxt
 
-Descubra nossa [lista de módulos](https://nuxt.com/modules) para super carregar o seu projeto Nuxt, criado pela equipa do Nuxt e pela comunidade.
+É possível descobrir na nossa [lista de módulos](https://nuxt.com/modules), códigos para impulsionar o nosso projeto de Nuxt, criados pela equipa e pela comunidade da Nuxt.
 
 - 165+ Módulos
-- 105+ Mantenedores
+- 105+ Colaboradores (Responsáveis)
 
 ::alert{type="next"}
-Consulte o [nuxt.com/modules](https://nuxt.com/modules)
+Consultar a [`nuxt.com/modules`](https://nuxt.com/modules).
 ::
 
 ![](/img/docs/modules.svg)
 
-Enquanto estiver desenvolvendo aplicações para produção com Nuxt você pode achar que o núcleo de funcionalidade do framework não é suficiente. O Nuxt pode ser estendido com opções de configuração e plugins, mas manter essas personalizações através de vários projetos é tedioso, repetitivo e consume tempo. Por outro lado, atender a cada necessidade do projeto fora da caixa tornaria o Nuxt muito complexo e difícil de usar.
+Ao programar aplicações de produção com a Nuxt, podemos descobrir que a funcionalidade principal da abstração não é suficiente. A Nuxt pode ser estendida com opções de configuração e extensões, mas a manutenção destas personalizações em vários projetos é tediosa, repetitiva e morosa. Por outro lado, suportar de imediato as necessidades de todos os projetos complicaria e dificultaria o uso da Nuxt.
 
-Esta é uma das razões do porquê o Nuxt fornecer um sistema de módulo de alta ordem que torna possível estender o núcleo. Os módulos são funções que são chamados sequencialmente sempre o Nuxt estiver iniciando. O framework espera cada módulo terminar antes de continuar. Desta maneira, os módulos podem personalizar quase qualquer aspeto da sua aplicação. Graças o desenho modular do Nuxt (baseado no [Tapable](https://github.com/webpack/tapable) do webpack), os módulos podem facilmente registar gatilhos para certos pontos de entrada como a inicialização do construtor. Os módulos podem também sobrescrever modelos, configurar os carregadores do webpack, adicionar bibliotecas CSS, e realizar muitas outras tarefas úteis.
+Esta é uma das razões pelas quais a Nuxt fornece um sistema de módulos de ordem superior que possibilita a extensão do núcleo. Os módulos são funções chamadas sequencialmente ao inicializar a Nuxt. A abstração espera cada módulo terminar antes de continuar. Desta maneira, os módulos podem personalizar quase todos os aspetos do nosso projeto. Graças ao desenho modular da Nuxt (baseado na [`tapable`](https://github.com/webpack/tapable) da Webpack), os módulos podem facilmente registar funções gatilhos para certos pontos de entrada como a inicialização do construtor. O módulos também podem sobrepor os modelos de marcação de hipertexto, configurar os carregadores da Webpack, adicionar bibliotecas de folhas de estilo em cascata, e realizar muitas outras tarefas úteis.
 
-O melhor de tudo, os módulos do Nuxt podem ser incorporados dentro dos pacotes npm. Isto torna possível re-usar através dos projetos e partilhar com a comunidade, ajudando a criar um ecossistema de recursos adicionáveis de alta qualidade.
+O melhor de tudo é que os módulos da Nuxt podem ser incorporados nos pacotes de `npm`. Isto permite a reutilização em vários projetos e a partilha com a comunidade, ajudando a criar um ecossistema de complementos (extensões) de alta qualidade.
 
-## A propriedade modules
+## A Propriedade `modules`
 
-Os módulos são extensões do Nuxt que podem estender a funcionalidade do núcleo do framework e adicionar integrações sem fim. Uma vez você ter instalado os módulos você pode então adicionar eles ao seu ficheiro `nuxt.config.js` dentro da propriedade `modules`.
+Os módulos são extensões de Nuxt que podem estender a funcionalidade principal da abstração e adicionar integrações infinitas. Depois de instalarmos os módulos, podemos adicioná-los ao nosso ficheiro `nuxt.config.js` na propriedade `modules`:
 
 ```js{}[nuxt.config.js]
 export default {
   modules: [
-    // Usando o nome do pacote
+    // Usar o nome do pacote.
     '@nuxtjs/axios',
 
-    // Relativo ao diretório fonte do seu projeto (srcDir)
+    // Relativo ao diretório de origem do nosso projeto.
     '~/modules/awesome.js',
 
-    // Fornecendo opções
+    // Fornecer opções
     ['@nuxtjs/google-analytics', { ua: 'X1234567' }],
 
     // Definição em linha
@@ -53,28 +54,28 @@ export default {
 ```
 
 ::alert{type="info"}
-Desenvolvedores de módulo geralmente fornecem passos adicionais necessários e detalhes para utilização.
+Os programadores de módulos fornecem normalmente os passos e os detalhes necessários para a sua utilização.
 ::
 
-O Nuxt tenta resolver cada item dentro do array de módulos usando o caminho exigido pelo node (dentro do `node_modules`) e depois resolverá a partir do `srcDir` se o apelido `@` for usado.
+A Nuxt tenta resolver cada elemento do vetor de módulos usando o caminho exigido pelo nó (no `node_modules`) e então resolverá a partir da `srcDir` do projeto se o pseudónimo `@` for usado.
 
 ::alert{type="warning"}
-Os módulos são executados sequencialmente, então a ordem é importante.
+Os módulos são executados sequencialmente, pelo que a ordem é importante.
 ::
 
-Os módulos devem exportar uma função para destacar a construção/tempo de execução e opcionalmente retorna uma promessa até que o trabalho deles esteja terminado. Repare que eles são importados em tempo de execução então eles devem já estar transpilados se estiverem usando as funcionalidades modernas do ES6.
+Os módulos devem exportar uma função para melhorar a construção e a execução e, opcionalmente, retornar uma promessa até o seu trabalho ser concluído. Notemos que são importados em execução, pelo que já devem ter sido traduzidos se utilizarem as funcionalidades modernas da ECMAScript 6.
 
-## Escreva o seu próprio módulo
+## Escrever o Nosso Próprio Módulo
 
-Os módulos são funções. Eles podem ser empacotados como módulos npm ou diretamente incluídos dentro do código-fonte do seu projeto.
+Os módulos são funções. Podem ser empacotados como módulos de `npm` ou incluídos diretamente no código-fonte do nosso projeto:
 
 ```js{}[nuxt.config.js]
 export default {
   exampleMsg: 'hello',
   modules: [
-    // Uso símples
+    // Uso simples
     '~/modules/example',
-    // Passando as opções diretamente
+    // Passar opções diretamente
     ['~/modules/example', { token: '123' }]
   ]
 }
@@ -90,23 +91,23 @@ export default function ExampleModule(moduleOptions) {
   })
 }
 
-// Obrigatório se estiver publicando o módulo como pacote npm
+// OBRIGATÓRIO se publicar o módulo como pacote de `npm`.
 module.exports.meta = require('./package.json')
 ```
 
-## 1) ModuleOptions
+## 1) `ModuleOptions`
 
-`moduleOptions`: este é o objeto passado usando o array `modules` pelo usuário. Podemos usar ele para personalizar seu comportamento,
+`moduleOptions`: este é o objeto passado pelo utilizador através do vetor `modules`. Podemos usá-lo para personalizar o seu comportamento.
 
-### Opções de alto nível
+### Opções de Alto Nível
 
-Algumas vezes é muito mais conveniente podermos usar opções de alto nível enquanto estivermos registando módulos dentro do `nuxt.config.js`. Isto permite-nos combinar várias fontes de opções. 
+Por vezes é mais conveniente se pudermos utilizar opções de nível superior ao registar módulos no `nuxt.config.js`. Isto permite-nos combinar várias fontes de opções:
 
 ```js{}[nuxt.config.js]
 export default {
   modules: [['@nuxtjs/axios', { anotherOption: true }]],
 
-  // o módulo axios está ciente disto ao usar `this.options.axios`
+  // o módulo `axios` está ciente disto ao usar `this.options.axios`
   axios: {
     option1,
     option2
@@ -114,126 +115,122 @@ export default {
 }
 ```
 
-## 2) this.options
+## 2) `this.options`
 
-`this.options`: Você pode acessar diretamente as opções do Nuxt usando esta referência. Este é o conteúdo do `nuxt.config.js` do usuário com todas opções padrão atribuídas a ela. Ela pode ser usada para opções partilhadas entre os módulos.
+`this.options`: pode acessar diretamente às opções da Nuxt ao utilizar esta referência. Este é o conteúdo do `nuxt.config.js` do utilizador com todas as opções predefinidas atribuídas a este. Pode ser utilizado para opções partilhadas entre módulos:
 
 ```js{}[module.js]
 export default function (moduleOptions) {
-  // `options` conterá option1, option2 e anotherOption
+  // `options` conterá `option1`, `option2` e `anotherOption`.
   const options = Object.assign({}, this.options.axios, moduleOptions)
 
   // ...
 }
 ```
 
-### Adicionar uma biblioteca CSS
+### Adicionar uma Biblioteca de Folha de Estilo
 
-Se o seu módulo fornecerá uma biblioteca CSS, certifique-se de realizar uma verificação para saber se o usuário já incluiu a biblioteca para evitar, e adicionar uma opção para desativar a biblioteca CSS dentro do módulo.
+Se o nosso módulo fornecer uma biblioteca de folha de estilo em cascata, devemos certificar-nos de que verificamos se o utilizador já incluiu a biblioteca para evitar duplicações e adicionar uma opção para desativar a biblioteca de folha de estilo no módulo:
 
 ```js{}[module.js]
 export default function (moduleOptions) {
   if (moduleOptions.fontAwesome !== false) {
-    // Adicione o font-awesome
+    // Adicionar a `font-awesome`
     this.options.css.push('font-awesome/css/font-awesome.css')
   }
 }
 ```
 
-### Emitir os recursos
+### Emitir Recursos ou Ativos
 
-Nós podemos registar os plugins do webpack para emitir os recursos durante a construção.
+Podemos registar as extensões da Webpack para emitir recursos durante a construção:
 
 ```js{}[module.js]
 export default function (moduleOptions) {
-  const info = 'Built by awesome module - 1.3 alpha on ' + Date.now()
+	const info = 'Built by awesome module - 1.3 alpha on ' + Date.now()
 
-  this.options.build.plugins.push({
-    apply(compiler) {
-      compiler.plugin('emit', (compilation, cb) => {
-        // Isto gerará o `.nuxt/dist/info.txt' com os conteúdos da variável info.
-        // A fonte (source) pode ser uma memória temporária também.
-        compilation.assets['info.txt'] = {
-          source: () => info,
-          size: () => info.length
-        }
-
-        cb()
-      })
-    }
-  })
+	this.options.build.plugins.push({
+		apply(compiler) {
+			compiler.hooks.emit.tap('info-plugin', (compilation) => {
+				compilation.assets['info.txt'] = {
+					source: () => info,
+					size: () => info.length
+				}
+			})
+		}
+	})
 }
 ```
 
-## 3) this.nuxt
+## 3) `this.nuxt`
 
-`this.nuxt`: Isto é uma referência a instância atual do Nuxt. Nós podemos registar gatilhos em certos eventos do ciclo de vida.
+`this.nuxt`: esta é uma referência para a instância atual da Nuxt. Podemos registar as funções gatilhos em certos eventos do ciclo de vida.
 
-- **Ready** : O Nuxt está pronto para trabalhar (ModuleContainer e Renderer prontos).
+- **`Ready`**: A Nuxt está pronta para funcionar (`ModuleContainer` e `Renderer` prontos).
 
 ```js
 nuxt.hook('ready', async nuxt => {
-  // O seu código personalizado vai aqui
+  // Nosso código personalizado...
 })
 ```
 
-- **Error**: Um erro não manipulado quando estiver chamando os gatilhos.
+- **`Error`**: Um erro não tratado ao chamar funções gatilhos.
 
 ```js
 nuxt.hook('error', async error => {
-  // O seu código personalizado vai aqui
+  // Nosso código personalizado...
 })
 ```
 
-- **Close**: A instância do Nuxt está fechando graciosamente.
+- **`Close`**: A instância da Nuxt fecha graciosamente.
 
 ```js
 nuxt.hook('close', async nuxt => {
-  // O seu código personalizado vai aqui
+  // Nosso código personalizado...
 })
 ```
 
-- **Listen**: O servidor interno do Nuxt começa ouvindo. (Usando o `nuxt start` ou `nuxt dev`)
+- **`Listen`**: O servidor interno da Nuxt começa a ouvir. (Ao utilizar o `nuxt start` ou `nuxt dev`).
 
 ```js
 nuxt.hook('listen', async (server, { host, port }) => {
-  // O seu código personalizado vai aqui
+  // Nosso código personalizado...
 })
 ```
 
-`this`: O contexto dos módulos. Todos os módulos são chamados dentro contexto da instância ModuleContainer.
+- `this`: contexto dos módulos. Todos os módulos serão chamados no contexto da instância da `ModuleContainer`.
 
-Consulte a documentação da classe [ModuleContainer](/docs/internals-glossary/internals-module-container) para conhecer os métodos disponíveis.
+Consultar a documentação da classe [`ModuleContainer`](/docs/internals-glossary/internals-module-container) por métodos disponíveis.
 
-### Executar tarefas em gatilhos específicos
+### Executar Tarefas em Funções Gatilhos Específicas
 
-O seu módulo pode precisar fazer coisas apenas sobre condições específicas e não somente durante a inicialização do Nuxt. Nós podemos usar os poderosos gatilhos do Nuxt para realizar tarefas em eventos específicos (baseado no [Hookable](https://github.com/nuxt-contrib/hookable)). O Nuxt esperará pela sua função para saber se ela retorna uma promessa ou está definida como `async`.
+O nosso módulo pode precisar de fazer coisas apenas em condições específicas e não apenas durante a inicialização da Nuxt. Podemos utilizar as poderosas funções gatilhos da Nuxt para realizar tarefas em eventos específicos (baseando na [`hookable`](https://github.com/nuxt-contrib/hookable)). A Nuxt aguardará por nossa função se esta retornar uma promessa ou for definida como `async`.
 
-Here are some basic examples:
+Eis alguns exemplos básicos:
 
 ```js{}[modules/myModule.js]
 export default function myModule() {
   this.nuxt.hook('modules:done', moduleContainer => {
-    // Isto será chamado quando todos os módulos terminarem o carregamento
+    // Será chamada quando todos os módulos tiverem terminado o carregamento.
   })
 
   this.nuxt.hook('render:before', renderer => {
-    // Chamado depois do renderizador ser criado
+    // Chamada depois do desenhador ser criado.
   })
 
   this.nuxt.hook('build:compile', async ({ name, compiler }) => {
-    // Chamado antes do compilador (padrão: webpack) começar
+    // Chamada depois do compilador (predefinido como: webpack) iniciar.
   })
 
   this.nuxt.hook('generate:before', async generator => {
-    // Isto será chamado antes do Nuxt gerar suas páginas
+    // Será chamada antes da Nuxt gerar as nossas páginas.
   })
 }
 ```
 
-### Fornecer plugins
+### Fornecer Extensões
 
-É comum que módulos forneçam um ou mais plugins quando adicionados. Por exemplo o módulo [bootstrap-vue](https://bootstrap-vue.js.org/) precisaria registar a si mesmo dentro do Vue. Em tais situações nós podemos usar o auxiliar `this.addPlugin`.
+É comum que os módulos forneçam uma ou mais extensões quando adicionados. Por exemplo, o módulo [`bootstrap-vue`](https://bootstrap-vue.org/) teria de registar-se na Vue. Nestas situações, podemos utilizar a auxiliar `this.addPlugin`:
 
 ```js{}[plugin.js]
 import Vue from 'vue'
@@ -246,25 +243,25 @@ Vue.use(BootstrapVue)
 import path from 'path'
 
 export default function nuxtBootstrapVue(moduleOptions) {
-  // Registe o modelo `plugin.js`
+  // Registar o molde `plugin.js`
   this.addPlugin(path.resolve(__dirname, 'plugin.js'))
 }
 ```
 
-**Observe que**: Quaisquer plugins injetados pelos módulos são adicionados no **princípio** da lista lista de plugins. Suas opções são:
-- Manualmente adicionar o plugin para o final da lista de plugins (`this.nuxt.options.plugins.push(...)`)
-- Inverter a ordem dos módulos se ele depender de um outro
+**Nota**: quaisquer extensões injetadas por módulos são adicionadas ao **início** da lista de extensões. As nossas opções são:
+- Adicionar manualmente a nossa extensão ao final da lista de extensões (`this.nuxt.options.plugins.push(...)`)
+- Inverter a ordem dos módulos se estes dependerem de outros.
 
-### Os plugins do modelo
+### Extensões do Molde de Conteúdo
 
-Os modelos registados e plugins podem influenciar o [os modelos do lodash](https://lodash.com/docs/4.17.4#template) para condicionalmente mudar a saída dos plugins registados.
+Os moldes e as extensões registadas podem influenciar os [moldes de conteúdo da `lodash`](https://lodash.com/docs/4.17.4#template) para alterar condicionalmente a saída das extensões registadas:
 
 ```js{}[plugin.js]
-// Define o Google Analytics UA
+// Definir o Google Analytics UA
 ga('create', '<%= options.ua %>', 'auto')
 
 <% if (options.debug) { %>
-// Apenas código do desenvolvedor
+// Exclusivo para código de desenvolvimento.
 <% } %>
 ```
 
@@ -272,57 +269,57 @@ ga('create', '<%= options.ua %>', 'auto')
 import path from 'path'
 
 export default function nuxtGoogleAnalytics(moduleOptions) {
-  // Registar o modelo `plugin.js`
+  // Registar o molde `plugin.js`
   this.addPlugin({
     src: path.resolve(__dirname, 'plugin.js'),
     options: {
-      // O Nuxt substituirá `options.ua` com `123` quando estiver copiando o plugin para o projeto
+      // A Nuxt substituirá `options.ua` por `123` ao copiar a extensão para o projeto.
       ua: 123,
 
-      // partes condicionais com `dev` será desfeito do código do plugin nas construções de produção
+      // Partes condicionais com `dev` serão retiradas do código da extensão nas construções de produção.
       debug: this.options.dev
     }
   })
 }
 ```
 
-### Registar carregadores personalizados do webpack
+### Registar Carregadores Personalizados da Webpack
 
-Nós podemos fazer o mesmo com o `build.extend` dentro do `nuxt.config.js` usando `this.extendBuild`.
+Podemos fazer o mesmo que `build.extend` no `nuxt.config.js` ao utilizar `this.extendBuild`:
 
 ```js{}[module.js]
 export default function (moduleOptions) {
     this.extendBuild((config, { isClient, isServer }) => {
-      // Carregador do `.foo`
+      // Carregador de `.foo`
       config.module.rules.push({
         test: /\.foo$/,
         use: [...]
       })
 
       // Personalizar carregadores existentes
-      // Recorra ao código-fonte para o interior do Nuxt:
+      // Consultar o código-fonte para conhecer os componentes internos da Nuxt:
       // https://github.com/nuxt/nuxt/blob/2.x-dev/packages/webpack/src/config/base.js
       const barLoader = config.module.rules.find(rule => rule.loader === 'bar-loader')
   })
 }
 ```
 
-## Os módulos assíncronos
+## Módulos Assíncronos
 
-Nem todos os módulos farão tudo de forma síncrona. Por exemplo, você talvez queira desenvolver um módulo que precisar requisitar alguma API ou fazer operações assíncronas. Para isto, o Nuxt suporta módulos assíncronos que podem retornar uma promessa ou chamar um callback.
+Nem todos os módulos farão tudo de maneira síncrona. Por exemplo, podemos querer programar um módulo que precise de buscar dados de alguma interface de programação de aplicação ou fazer uma operação assíncrona. Para isto, a Nuxt suporta módulos assíncronos que podem retornar uma promessa ou chamar uma função de resposta.
 
-### Use o async/await
+### Usar a `async/await`
 
 ```js
 import fse from 'fs-extra'
 
 export default async function asyncModule() {
-  // Você pode fazer trabalho assíncrono aqui usando `async`/`await`
+  // Podemos trabalhar de maneira assíncrona neste caso ao usar `async`/`await`.
   const pages = await fse.readJson('./pages.json')
 }
 ```
 
-### Retornar uma promessa
+### Retornar uma Promessa
 
 ```js
 export default function asyncModule($http) {
@@ -330,30 +327,30 @@ export default function asyncModule($http) {
     .get('https://jsonplaceholder.typicode.com/users')
     .then(res => res.data.map(user => '/users/' + user.username))
     .then(routes => {
-      // Faça alguma coisa ao estender as rotas do nuxt
+      // Estender as rotas da Nuxt
     })
 }
 ```
 
 ::alert{type="info"}
-Existem mais gatilhos e possibilidades para módulos. Consulte o [Interior do Nuxt](/docs/internals-glossary/internals) para achar mais informações sobre a API nuxt-internal.
+Há muito mais funções gatilhos e possibilidades para os módulos. Consultar o [Interior da Nuxt](/docs/internals-glossary/internals) para encontrar mais sobre a interface de programação de aplicação dos componentes internos da Nuxt.
 ::
 
-## Publicando o seu módulo
+## Publicar o Nosso Módulo
 
-`module.exports.meta`: Esta linha é exigida se você estiver publicando o módulo como um pacote npm. O Nuxt usa internamente o `meta` para trabalhar melhor com seu pacote.
+`module.exports.meta`: esta linha é necessária se publicarmos o módulo como um pacote de `npm`. A Nuxt usa internamente a `meta` para trabalhar melhor com o nosso pacote:
 
 ```js{}[modules/myModule.js]
 module.exports.meta = require('./package.json')
 ```
 
-## A propriedade buildModules
+## `buildModules`
 
-Alguns módulos são apenas importados durante o tempo de desenvolvimento e construção. Usar `buildModules` ajuda tornar inicio da produção rápido e também diminuir significativamente o tamanho do seu diretório `node_modules` para deployments em produção. Recorra à documentação para cada módulo para ver se é recomendado usar a propriedade `modules` ou `buildModules`.
+Alguns módulos só são importados durante o desenvolvimento e construção. Usar `buildModules` ajuda a acelerar a inicialização da produção e também diminui significativamente o tamanho dos nossos `node_modules` para implantações de produção. Consultar a documentação de cada módulo para ver se é recomendado utilizar `modules` ou `buildModules`.
 
-A diferença de uso é:
+A diferença de utilização é:
 
-- Ao invés de adicionar ao `modules` dentro do `nuxt.config.js`, adicione ao `buildModules`
+- Ao invés de adicionar `modules` dentro do `nuxt.config.js`, utilizar `buildModules`:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -361,7 +358,7 @@ export default {
 }
 ```
 
-- Ao invés de adicionar ao `dependencies` dentro do `package.json`, adicione ao `devDependencies`
+- Ao invés de adicionar `dependencies` dentro do `package.json`, utilizar `devDependencies`:
 
 ::code-group
 ```bash [Yarn]
@@ -373,16 +370,16 @@ npm install --save-dev @nuxtjs/eslint-module
 ::
 
 ::alert{type="info"}
-Se você é um autor de módulo, é altamente recomendado sugerir aos usuários que instalem o seu pacote como uma `devDependency` e usar o `buildModules` ao invés de `modules` para o `nuxt.config.js`.
+Se formos um autor de módulo, é altamente recomendado sugerir aos utilizadores que instalem o nosso pacote como uma `devDependency` e utilizem `buildModules` em vez de `modules` para `nuxt.config.js`.
 ::
 
-O seu módulo é um `buildModules` a menos que:
+O nosso módulo é um `buildModule` a menos que:
 
-- Ele esteja fornecendo um serverMiddleware
-- Ele tem de registar um gatilho para o tempo de execução do Node.js (como sentry)
-- Ele esteja afetando o comportamento do vue-renderer ou usando um gatilho do espaço de nome `server:` ou `vue-renderer`
-- Outra coisa que esteja fora do escopo do webpack (sugestão: plugins e modelos que são compilados e estão dentro do escopo do webpack)
+- Fornece um `serverMiddleware`.
+- Regista uma função gatilho de execução da Node.js (como `sentry`).
+- Afeta o comportamento da `vue-renderer` ou utiliza uma função gatilho do espaço nominal `server:` ou `vue-renderer`.
+- Qualquer outra coisa fora do âmbito de aplicação da Webpack (Dica: extensões e moldes são compilados e estão no âmbito de aplicação da Webpack).
 
 ::alert{type="warning"}
-Se você está oferecendo o uso do `buildModules` mencione que esta funcionalidade está apenas disponível a partir da versão 2.9 do Nuxt. Usuários antigos devem atualizar ou usar a secção `modules`.
+Se formos fornecer o uso de `buildModules`, precisamos mencionar que este recurso só está disponível a partir da Nuxt v2.9. Os utilizadores mais antigos devem atualizar a Nuxt ou utilizar a secção `modules`.
 ::

--- a/content/pt/docs/4.directory-structure/9.pages.md
+++ b/content/pt/docs/4.directory-structure/9.pages.md
@@ -1,21 +1,22 @@
 ---
-title: O diretório pages
-navigation.title: páginas
-description: O diretório pages contém as views e rotas da sua aplicação. O Nuxt lê todos os ficheiros .vue dentro deste diretório e cria automaticamente a configuração do router por você.
+title: Diretório de Páginas
+navigation.title: pages
+description: O diretório de páginas contém as visões e rotas da nossa aplicação. A Nuxt lê todos os ficheiros abstratos dentro deste diretório e cria automaticamente a configuração do roteador para nós.
 category: directory-structure
 csb_link: https://codesandbox.io/embed/github/nuxt-academy/guides-examples/tree/master/04_directory_structure/11_pages?fontsize=14&hidenavigation=1&theme=dark
 ---
-# O diretório pages
 
-O diretório `pages` contém as views e rotas da sua aplicação. O Nuxt lê todos os ficheiros `.vue` dentro deste diretório e cria automaticamente a configuração do router por você.
+# Diretório de Páginas
+
+O diretório `pages` contém as visões e rotas da nossa aplicação. A Nuxt lê todos os ficheiros `.vue` dentro deste diretório e cria automaticamente a configuração do roteador para nós.
 
 ---
 
 ::alert{type="info"}
-Você pode também criar rotas com ficheiros .js e .ts
+Também podemos criar rotas com ficheiros `.js` e `.ts`.
 ::
 
-Todo componente de página é um componente Vue mas o Nuxt adiciona atributos e funções especiais para tornar o desenvolvimento da sua aplicação universal o mais fácil possível. 
+Cada componente de página é um componente `.vue`, mas a Nuxt acrescenta atributos e funções especiais para facilitar o máximo possível o desenvolvimento da nossa aplicação universal:
 
 ```html{}[pages]
 <template>
@@ -24,7 +25,7 @@ Todo componente de página é um componente Vue mas o Nuxt adiciona atributos e 
 
 <script>
   export default {
-    // as propriedades da página vão aqui
+    // as propriedades da página estarão neste objeto.
   }
 </script>
 
@@ -35,32 +36,32 @@ Todo componente de página é um componente Vue mas o Nuxt adiciona atributos e 
 </style>
 ```
 
-## Páginas dinâmicas
+## Páginas Dinâmicas
 
-As páginas dinâmicas podem ser criadas quando você não sabe o nome da página devido ao fato dela vir de uma API ou você não quer ter de criar a mesma página uma vez a outra. Para criar uma página dinâmica você precisa adicionar um sublinhado antes do nome do ficheiro .vue ou antes do nome do diretório, se você quiser que o diretório seja dinâmico. Você pode nomear o ficheiro ou diretório com o que você quiser mas você deve adicionar um prefixo nele com um sublinhado.
+As páginas dinâmicas podem ser criadas quando não sabemos o nome da página devido ao fato de ser proveniente duma interface de programação de aplicação, ou quando não queremos ter de criar a mesma página vezes sem conta. Para criar uma página dinâmica, temos de adicionar um sublinhado antes do nome do ficheiro `.vue`, ou antes, do nome do diretório, se quisermos que o diretório seja dinâmico. Podemos dar ao ficheiro ou diretório o nome que quisermos, mas temos de o prefixar com um sublinhado.
 
-Se você tiver definido um ficheiro nomeado como `_slug.vue` dentro da sua pastas pages, você pode acessar o valor usando o contexto com o params.slug.
+Se tivermos definido um ficheiro chamado `_slug.vue` na nossa pasta `pages`, podemos acessar o valor ao utilizar o contexto com a `params.slug`:
 
 ```html{}[pages/_slug.vue]
 <template>
-  <h1>{{ this.slug }}</h1>
+  <h1>{{ slug }}</h1>
 </template>
 
 <script>
   export default {
     async asyncData({ params }) {
-      const slug = params.slug // Quando estiver chamando /abc o slug será "abc"
+      const slug = params.slug // Ao chamar `/abc`, a `slug` será "abc".
       return { slug }
     }
   }
 </script>
 ```
 
-Se você tiver definido um ficheiro nomeado como `_slug.vue` dentro de uma pasta chamada `_hook` você pode acessar o valor usando o contexto com o `params.slug` e o `params.book`
+Se definimos um ficheiro chamado `_slug.vue` numa pasta chamada `_book` podemos acessar o valor ao utilizar o contexto com `params.slug` e `params.book`: 
 
 ```html{}[pages/_book/_slug.vue]
 <template>
-  <h1>{{ this.book }} / {{ this.slug }}</h1>
+  <h1>{{ book }} / {{ slug }}</h1>
 </template>
 
 <script>
@@ -76,9 +77,9 @@ Se você tiver definido um ficheiro nomeado como `_slug.vue` dentro de uma pasta
 
 ## Propriedades
 
-### A propriedade asyncData
+### `asyncData`
 
-O asyncData é chamado toda vez antes do componente de carregamento. Ele pode ser assíncrono e receber o contexto como um argumento. O objeto retornado será combinado com o seu objeto data.
+A `asyncData` é chamada todas as vezes antes de carregar o componente. Esta pode ser assíncrono e recebe o contexto como argumento. O objeto retornado será fundido com o nosso objeto de dados:
 
 ```js{}[pages/index.vue]
 export default {
@@ -89,12 +90,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais sobre como o asyncData funciona consulte o nosso capítulo [Requisição de Dados](/docs/features/data-fetching#dados-assíncronos)
+Saber mais sobre como `asyncData` funciona no nosso capítulo de [Obtenção de Dados](/docs/features/data-fetching#dados-assíncronos).
 ::
 
-### A propriedade fetch
+### `fetch`
 
-Toda vez que você precisar receber dados assíncronos você pode usar o fetch. O fetch é chamado no lado do servidor quando estiver renderizando a rota, e no lado do cliente quando estiver navegando.
+Sempre que precisarmos de obter dados assíncronos, podemos utilizar a `fetch`. A `fetch` é chamada no lado do servidor ao desenhar a rota e no lado do cliente ao navegar:
 
 ```html
 <script>
@@ -114,28 +115,28 @@ Toda vez que você precisar receber dados assíncronos você pode usar o fetch. 
 ```
 
 ::alert{type="next"}
-Para saber mais sobre como o fetch funciona consulte o nosso capítulo [Requisição de Dados](/docs/features/data-fetching)
+Saber mais sobre como a `fetch` funciona no nosso capítulo de [Obtenção de Dados](/docs/features/data-fetching).
 ::
 
-### A propriedade head
+### `head`
 
-Definir marcadores de `<meta>` específicas para página atual. O Nuxt usa o `vue-meta` para atualizar o head e meta atributos do documento da sua aplicação.
+Define os marcadores de `<meta>` específicos para a página atual. A Nuxt utiliza a `vue-meta` para atualizar o cabeçalho do documento e meta-atributos da nossa aplicação:
 
 ```js{}[pages/index.vue]
 export default {
   head() {
-    // Defina os marcadores de meta para esta página
+    // Definir meta-marcadores para esta página.
   }
 }
 ```
 
 ::alert{type="next"}
-Para saber mais sobre o head consulte o nosso capítulo [Marcadores de Meta e SEO](/docs/features/meta-tags-seo)
+Saber mais no nosso capítulo [Meta-Marcadores e Otimização do Motor de Pesquisa](/docs/features/meta-tags-seo).
 ::
 
-### A propriedade layout
+### `layout`
 
-Específica um esquema definido dentro do diretório de layouts.
+Especifica uma disposição no diretório de disposições (`layouts/`):
 
 ```js{}[pages/index.vue]
 export default {
@@ -144,12 +145,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais sobre layouts consulte o nosso capítulo de [Apresentações](/docs/concepts/views#layouts).
+Saber mais sobre as disposições no nosso capítulo de [Visões](/docs/concepts/views#disposições).
 ::
 
-### A propriedade loading
+### `loading`
 
-Se definido para false, previne que uma página de automaticamente chamar `this.$nuxt.$loading.finish()` assim que você entrar nela e `this.$nuxt.$loading.start()` assim que você sair dela, permitindo que você manualmente controle o comportamento, assim como é mostrado no [exemplo](/examples/loading/custom-loading-component).
+Se definida como `false`, impedi que uma página chame automaticamente `this.$nuxt.$loading.finish()` quando entramos nela e `this.$nuxt.$loading.start()` quando saímos dela, permitindo-nos controlar manulamente o comportamento, como mostra [este exemplo](/examples/loading/custom-loading-component):
 
 ```js{}[pages/index.vue]
 export default {
@@ -158,16 +159,16 @@ export default {
 ```
 
 ::alert{type="info"}
-Apenas se aplica se loading estiver também definido dentro de `nuxt.config.js`.
+Só se aplica se a `loading` também estiver definido em `nuxt.config.js`.
 ::
 
 ::alert{type="next"}
-Para saber mais sobre loading consulte o nosso capítulo [Carregamento](/docs/features/loading).
+Saber mais no capítulo de [Carregamento](/docs/features/loading).
 ::
 
-### A propriedade transition
+### `transition`
 
-Define uma transição específica para a página.
+Define uma transição específica para a página:
 
 ```js{}[pages/index.vue]
 export default {
@@ -176,12 +177,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais sobre transition consulte o nosso capítulo [Transições](/docs/features/transitions).
+Saber mais sobre transições no nosso capítulo de [Transições](/docs/features/transitions).
 ::
 
-### A propriedade scrollToTop
+### `scrollToTop`
 
-A propriedade `scrollToTop` permite você dizer ao Nuxt para rolar a página até ao topo antes da renderização da página. Por padrão, o Nuxt rola para o topo quando você vai para uma outra página, mas com as rotas filhas, o Nuxt mantém a posição da rolagem. Se você quiser dizer ao Nuxt para rolar para o topo quando estiver renderizando sua rota filha, defina `scrollToTop` para `true`
+A propriedade `scrollToTop` permite-nos dizer a Nuxt para deslocar até o topo antes de desenhar a página. Por predefinição, a Nuxt desloca-se para o topo quando vamos a outra página, mas com as rotas filhas (secundárias), a Nuxt mantém a posição da deslocação. Se quisermos dizer a Nuxt para deslocar para o topo ao desenhar a nossa rota filha, definimos `scrollToTop` como `true`:
 
 ```js{}[pages/index.vue]
 export default {
@@ -189,14 +190,13 @@ export default {
 }
 ```
 
-Pelo contrário, você pode manualmente definir `scrollToTop` para `false` no pai das rotas também.
+Por outro lado, também podemos definir manualmente `scrollTopTop` para `false` nas rotas pai (primárias).
 
+Se quisermos sobrescrever o comportamento do deslocamento predefinido da Nuxt, podemos olhar a [opção `scrollBehavior`](/docs/configuration-glossary/configuration-router#scrollbehavior).
 
-Se você quiser sobrescrever o comportamento padrão de rolagem do Nuxt, de uma vista de olhos na [opção scrollBehavior](/docs/configuration-glossary/configuration-router#scrollbehavior).
+### `middleware`
 
-### A propriedade middleware
-
-Define um intermediário para esta página. O intermediário será chamado antes da renderização da página.
+Define o intermediário para esta página. O intermediário será chamado antes de desenhar a página:
 
 ```js{}[pages/index.vue]
 export default {
@@ -205,12 +205,12 @@ export default {
 ```
 
 ::alert{type="next"}
-Para saber mais sobre middleware consulte o nosso capítulo [Intermediário](/docs/directory-structure/middleware).
+Saber mais sobre o intermediário no nosso capítulo de [Intermediário](/docs/directory-structure/middleware).
 ::
 
-### A propriedade watchQuery (observar consulta)
+### A Propriedade `watchQuery`
 
-Use a chave `watchQuery` para definir um observador para as strings da consulta. Se a string definida mudar, todos os métodos do componente (asyncData, fetch(context), validate, layout, ...) serão chamados. A observação está desativada por padrão para melhorar a performance.
+Utilizamos a chave `watchQuery` para definir um observador para as sequências de caracteres de consulta. Se as sequências de caracteres definidas mudarem, todos os métodos do componente (`asyncData`, `fetch(context)`, `validate`, `layout`, ...) serão chamados. A observação está desativada por predefinição para melhorar o desempenho:
 
 ```js{}[pages/index.vue]
 export default {
@@ -219,7 +219,7 @@ export default {
 ```
 
 ::alert{type="warning"}
-**Aviso**: O novo gatilho `fetch` introduzido na versão 2.12 não é afetado pelo `watchQuery`. Para obter mais informações consulte [ouvindo a mudanças na string da consulta](/docs/features/data-fetching#o-gatilho-hook).
+**Aviso**: A nova função gatilho `fetch` introduzida na versão 2.12 não é afetada pela `watchQuery`. Para mais informações, podemos consultar [ouvir alterações na sequência de caracteres de consulta](/docs/features/data-fetching#ouvir-as-alterações-da-sequência-de-caracteres-de-consulta).
 ::
 
 ```js{}[pages/index.vue]
@@ -228,57 +228,57 @@ export default {
 }
 ```
 
-Você pode também usar a função `watchQuery(newQuery, oldQuery)` para ter observadores mais refinados.
+Também podemos usar a função `watchQuery(newQuery, oldQuery)` para termos observadores mais refinados:
 
 ```js{}[pages/index.vue]
 export default {
   watchQuery(newQuery, oldQuery) {
-    // Apenas execute os métodos do componente se a antiga sequência de caracteres da consulta conter `bar`
-    // e a nova sequência de caracteres da consulta conter `foo`
+    // Só executa os métodos do componente se sequência de caracteres antiga contiver `bar`
+    // e a nova sequência de caracteres de consulta contém `foo`
     return newQuery.foo && oldQuery.bar
   }
 }
 ```
 
 ::alert{type="next"}
-Para saber mais sobre watchQuery consulte o nosso capítulo [Requisição de Dados](/docs/features/data-fetching).
+Saber mais sobre a propriedade `watchQuery` no nosso capítulo de [Obtenção de Dados](/docs/features/data-fetching).
 ::
 
-### A propriedade key
+### `key`
 
-O mesmo é com a propriedade `key` que pode ser usada nos componentes Vue dentro dos modelos como uma dica para a DOM virtual, esta propriedade permite que a chave e valor sejam definidas a partir da própria página (em vez do componente pai).
+Da mesma maneira que a propriedade `key` que pode ser usada em componentes `.vue` em modelos de marcação de hipertexto como uma dica para o modelo de objeto do documento virtual, esta propriedade permite que o valor da chave seja definido a partir da própria página (em vez do componente pai (primário)).
 
-Por padrão dentro Nuxt, este valor será o `$route.path`, querendo dizer que a navegação para uma rota diferente garantirá que um componente de página limpo seja criado. Logicamente equivalente a:
+Por predefinição, na Nuxt, este valor será a `$route.path`, o que significa que navegar para uma rota diferente garantirá que um componente de página limpo seja criado. Logicamente equivalente a:
 
 ```html
 <router-view :key="$route.path" />
 ```
 
-A propriedade pode ser uma `String` ou uma `Function` que recebe uma rota como o primeiro argumento.
+A propriedade pode ser uma `String` ou uma `Function` que recebe uma rota como primeiro argumento.
 
-## Ignorando páginas
+## Ignorar Páginas
 
-Se você quiser ignorar páginas para que elas não sejam incluídas dentro do ficheiro `router.js` gerado, então você pode ignorar elas ao prefixar elas com um `-`.
+Se quisermos ignorar páginas para estas não serem incluídas no ficheiro `router.js` gerado, então podemos ignorá-las prefixando-as com um `-`.
 
-Por exemplo, `pages/-about.vue` será ignorada.
+Por exemplo, `pages/-about.vue` será ignorado.
 
 ::alert{type="next"}
-Consulta a [opção ignore](/docs/configuration-glossary/configuration-ignore) para aprender mais sobre ela.
+Consultar a [opção `ignore`](/docs/configuration-glossary/configuration-ignore) para saber mais sobre esta.
 ::
 
 ## Configuração
 
-Você pode renomear o diretório `pages/` para alguma coisa diferente ao definir a opção `dir.pages`:
+Podemos renomear o diretório `pages/` para algo diferente ao definir a opção `dir.pages`:
 
 ```js{}[nuxt.config.js]
 export default {
   dir: {
-    // Renomeia o diretório `pages` para `routes`
+    // Renomear o diretório `pages` para `routes`
     pages: 'routes'
   }
 }
 ```
 
 ::alert{type="next"}
-Consulte a [opção dir](/docs/configuration-glossary/configuration-dir) para aprender mais sobre ela.
+Consultar a [opção `dir`](/docs/configuration-glossary/configuration-dir) para saber mais sobre esta.
 ::

--- a/content/pt/docs/4.directory-structure/index.md
+++ b/content/pt/docs/4.directory-structure/index.md
@@ -1,5 +1,5 @@
 ---
-title: Estrutura de Diretório
+title: Estrutura do Diretório
 navigation:
   collapse: true
   redirect: /docs/directory-structure/nuxt


### PR DESCRIPTION
In this request to update the main branch of the repository, I'm sending the changes applied to the contents of the `directory-structure` folder in the Portuguese documentation.

I know that some may consider it a waste of time to update this material, but I believe that anyone who thinks this way has no real idea of how many existing projects still use Nuxt 2. 

Depending on the size of the project, there is a lot of bureaucracy and effort to overcome before you can start thinking about updating the technology stack.

My reasons go a little further than the points mentioned above, because I also want to standardise the language with the one I'll be using to translate the Nuxt 3 website.