### PR TITLE
Fix Accessibility Violation - Add Label to Language Switcher

### DIFF
--- a/components/molecules/forms/LangSwitcher.vue
+++ b/components/molecules/forms/LangSwitcher.vue
@@ -6,6 +6,7 @@
     placement="bottom"
     mode="hover"
     class="inline-flex items-center w-12 h-12"
+    label="Language switcher"
   >
     <template #trigger>
       <IconTranslate class="d-icon" :class="iconClass" />


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2273

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This PR fixes an accessibility violation where the language switcher dropdown in the navigation lacks an accessible name, making it unusable for screen reader users.

#### Problem
The IBM Equal Access Accessibility Checker identified a violation:

- Issue: The SVG element (language switcher icon) has no accessible name
- Element: <IconTranslate> component within a dropdown trigger
- Impact: Screen reader users cannot identify the purpose of this interactive element. They cannot tell that it's a language switcher or understand what will happen when they interact with it.

<img width="2560" height="840" alt="image" src="https://github.com/user-attachments/assets/41a23723-5936-4912-a9eb-146eea8b5ddb" />

#### Solution
Added a `label="Language switcher"` prop to the dropdown component, which provides a clear, descriptive accessible name for screen reader users. This label:

- Clearly identifies the control as a language switcher
- Follows common web conventions for language selection controls
- Provides meaningful context without cluttering the visual design
