### PR TITLE
Fix broken fallback image in ContentCardTemplate — source.unsplash.com/random is deprecated (503)

### DIFF
--- a/components/molecules/cards/ContentCardTemplate.vue
+++ b/components/molecules/cards/ContentCardTemplate.vue
@@ -76,7 +76,7 @@ export default defineComponent({
     }
   },
   setup(props) {
-    const imgUrl = computed(() => props.image || 'https://source.unsplash.com/random')
+    const imgUrl = computed(() => props.image || 'https://images.unsplash.com/photo-1763568258327-034710107b93?w=800&h=500&fit=crop&q=80')
 
     function navigateToUrl(href) {
       const isInternal = href.startsWith('/') && href.startsWith('//') === false


### PR DESCRIPTION
Fix for issue #2276.

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and now returns 503 / times out. `ContentCardTemplate.vue` L79 used the endpoint as the image fallback, so any `ContentCard` rendered without an explicit `props.image` shipped a broken `<img>` on the live Nuxt site.

## Change

One-line: swap the fallback URL to a specific, permanent `images.unsplash.com` photo pinned to 800×500 at q=80.

- Photo ID: `1763568258327-034710107b93` (a laptop-with-code shot; fits the dev-oriented cards).
- No CORS/auth changes needed; Unsplash CDN URLs in this form are stable long-term.
- Reverts trivially if you'd rather use a local asset in `public/` — happy to push a follow-up that commits a bundled JPG instead.

## Reproduce the bug

```
curl -I https://source.unsplash.com/random
```

Returns 503, or `HTTP/2 404` on redirect, depending on region. See https://help.unsplash.com/en/articles/8656599-unsplash-source-is-deprecated for the official deprecation notice.

## Context

I ran a GitHub code search on 2026-04-21 — ~16,500 files across ~885 unique repos still reference this dead endpoint. Writeup (including this repo): https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md

- Kushal